### PR TITLE
notifyicon.go: add support for successfully creating NotifyIcons when…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@
 # Contributors
 # ============
 
+Aaron Klotz <aaron@tailscale.com>
 Alexander Neumann <an2048@gmail.com>
 Aman Gupta <aman@tmm1.net>
 Anthony Dong <adongy@users.noreply.github.com>

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 )
 
 replace (
-	github.com/lxn/walk => github.com/tailscale/walk v0.0.0-20210112085537-c389da54e794
-	github.com/lxn/win => github.com/tailscale/win v0.0.0-20211102182607-087472efce52
+	github.com/lxn/walk => github.com/tailscale/walk v0.0.0-20211102184543-a1629da8e766
+	github.com/lxn/win => github.com/tailscale/win v0.0.0-20211102205409-55fb19b60559
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/tailscale/walk v0.0.0-20210112085537-c389da54e794 h1:misk6AIwfNWMTEcDcB0ww97z/Om7EF3kAVSTCy3KK1w=
-github.com/tailscale/walk v0.0.0-20210112085537-c389da54e794/go.mod h1:2A8sVOCfHDtfaRQ7LbQbX2ODLD6RDf8bVRl6ZosnRRE=
-github.com/tailscale/win v0.0.0-20211102182607-087472efce52 h1:g2llw+LZ/iYZzGVhuPhR7CAdxFFm/7K3H+YivLVSS6A=
-github.com/tailscale/win v0.0.0-20211102182607-087472efce52/go.mod h1:pW76gHd94DwbTRePyhfsevz9KvQJHBtNT7vZ+TmqBCs=
+github.com/tailscale/walk v0.0.0-20211102184543-a1629da8e766 h1:kECwlp2VlKhR2dlImNZXVzAzo+L2YTJoSA9UKxm6rOI=
+github.com/tailscale/walk v0.0.0-20211102184543-a1629da8e766/go.mod h1:NXsqAC97i9TpxbWLrzI5gZcSYs0tz9IIh308SJWTPp4=
+github.com/tailscale/win v0.0.0-20211102205409-55fb19b60559 h1:kzb5fYHE2i3ERDTJNpK1ifRQXNAJPLKZ0mhQxxHt9FI=
+github.com/tailscale/win v0.0.0-20211102205409-55fb19b60559/go.mod h1:pW76gHd94DwbTRePyhfsevz9KvQJHBtNT7vZ+TmqBCs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c h1:QOfDMdrf/UwlVR0UBq2Mpr58UzNtvgJRXA4BgPfFACs=
 golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
… the taskbar is not present.

Until now, when the taskbar is not present (perhaps the application has been
started before the shell), creating a `NotifyIcon` will fail.

We can detect the presence of the taskbar by calling `SHAppBarMessage`.
If we determine that the taskbar is not present, we still successfully
create the `NotifyIcon` and the application may continue to mutate the
icon's state.

Since we already handle `TaskbarCreated` messages, we leverage that
existing functionality to then populate the notification icon once
the shell has started.

One problem that this creates is that, until now, `NotifyIcon` always
assumed that it had a valid notify icon ID. I refactored its
implementation to make it compatible with the notion that it may not
yet have an ID.

I added additional separation between the framework state tracked by
`NotifyIcon` and the state+execution of the shell APIs themselves:

A new struct, `shellNotificationIcon`, hosts the ID and HWND for the
icon. To mutate state, we call `shellNotificationIcon.newCmd` to create
a `niCmd` struct that executes mutations.

If the notification icon does not yet exist, `newCmd` returns a `nil`
`niCmd`. However, this is non-fatal and the `NotifyIcon` continues to
hold updated application state.

Notice that the `NOTIFYICONDATA.CbSize` field is now set to the
full size of that structure: I decided that I wanted to use the
HBalloonIcon field for balloon icons. This is still compatible with
the Windows XP compatible `NIM_SETVERSION` stuff: It is quite reasonable
to request Windows XP semantics for the notification icon's messaging
while simultaneously using a newer revision of the `NOTIFYICONDATA`
structure. The messaging semantics for the notification icon are
orthogonal to the ABI revision of the `NOTIFYICONDATA` structure.

As an added bonus, this means that we only need one call to
`Shell_NotifyIcon` to create a balloon notification with a user-defined icon.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>