### PR TITLE
notifyicon.go: use existing visibility state when re-adding icon

### DIFF
--- a/notifyicon.go
+++ b/notifyicon.go
@@ -277,7 +277,7 @@ func (ni *NotifyIcon) isDefunct() bool {
 func (ni *NotifyIcon) readdToTaskbar() error {
 	cmd := ni.shellIcon.newCmd(win.NIM_ADD)
 	cmd.setCallbackMessage(notifyIconMessageId)
-	cmd.setVisible(true)
+	cmd.setVisible(ni.visible)
 	cmd.setIcon(ni.getHICON(ni.icon))
 	if err := cmd.setToolTip(ni.toolTip); err != nil {
 		return err


### PR DESCRIPTION
Trivial fix.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>