### PR TITLE
notifyicon.go: change Shell_NotifyIcon to use win.lastError instead o…

### DIFF
--- a/notifyicon.go
+++ b/notifyicon.go
@@ -203,7 +203,7 @@ func (cmd *niCmd) setVisible(v bool) {
 
 func (cmd *niCmd) execute() error {
 	if !win.Shell_NotifyIcon(cmd.op, &cmd.nid) {
-		return newError("Shell_NotifyIcon")
+		return lastError("Shell_NotifyIcon")
 	}
 
 	if cmd.op != win.NIM_ADD {


### PR DESCRIPTION
…f win.newError

MSDN docs really suck here, as they do not indicate that `GetLastError` is valid
when `Shell_NotifyIcon` returns false. However, the disassembly indicates that
it is in fact used.

Let's update this so that we can get better errors when the call fails.

Updates https://github.com/tailscale/tailscale/issues/4133

Signed-off-by: Aaron Klotz <aaron@tailscale.com>