### PR TITLE
go.mod, notifyicon.go: update call to Shell_NotifyIcon to use improve…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 )
 
 replace (
-	github.com/lxn/walk => github.com/tailscale/walk v0.0.0-20211102184543-a1629da8e766
-	github.com/lxn/win => github.com/tailscale/win v0.0.0-20211213204608-c3f813abca9f
+	github.com/lxn/walk => github.com/tailscale/walk v0.0.0-20220506150313-ed127cfb919a
+	github.com/lxn/win => github.com/tailscale/win v0.0.0-20221118185520-e8ccca099752
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/tailscale/walk v0.0.0-20211102184543-a1629da8e766 h1:kECwlp2VlKhR2dlImNZXVzAzo+L2YTJoSA9UKxm6rOI=
-github.com/tailscale/walk v0.0.0-20211102184543-a1629da8e766/go.mod h1:NXsqAC97i9TpxbWLrzI5gZcSYs0tz9IIh308SJWTPp4=
-github.com/tailscale/win v0.0.0-20211213204608-c3f813abca9f h1:VRYHqFM2JIfGJOdvq8Ts5Bmayqj8Ybcn5GIpzEfZWNo=
-github.com/tailscale/win v0.0.0-20211213204608-c3f813abca9f/go.mod h1:pW76gHd94DwbTRePyhfsevz9KvQJHBtNT7vZ+TmqBCs=
+github.com/tailscale/walk v0.0.0-20220506150313-ed127cfb919a h1:uptpnGzRLeSxntDX81sonfvoqxSH54COkJcX14TYWAo=
+github.com/tailscale/walk v0.0.0-20220506150313-ed127cfb919a/go.mod h1:8mDkfXFy+FtezqBBO6mTwoBpW32aetZkrZxBNrdoU3A=
+github.com/tailscale/win v0.0.0-20221118185520-e8ccca099752 h1:HEjbCnclYTqYGERu4RVMkU6cczgpzUd5TQbvT1AStbw=
+github.com/tailscale/win v0.0.0-20221118185520-e8ccca099752/go.mod h1:pW76gHd94DwbTRePyhfsevz9KvQJHBtNT7vZ+TmqBCs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c h1:QOfDMdrf/UwlVR0UBq2Mpr58UzNtvgJRXA4BgPfFACs=
 golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/notifyicon.go
+++ b/notifyicon.go
@@ -8,6 +8,7 @@
 package walk
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"unsafe"
@@ -202,8 +203,8 @@ func (cmd *niCmd) setVisible(v bool) {
 }
 
 func (cmd *niCmd) execute() error {
-	if !win.Shell_NotifyIcon(cmd.op, &cmd.nid) {
-		return lastError("Shell_NotifyIcon")
+	if err := win.Shell_NotifyIcon(cmd.op, &cmd.nid); err != nil {
+		return fmt.Errorf("Shell_NotifyIcon: %w", err)
 	}
 
 	if cmd.op != win.NIM_ADD {


### PR DESCRIPTION
…d error handling

Update the reference to tailscale/win, then update to work with the new signature for Shell_NotifyIcon.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>