### PR TITLE
all: replace all import references to upstream with our own fork

### DIFF
--- a/accessibility.go
+++ b/accessibility.go
@@ -6,7 +6,7 @@
 
 package walk
 
-import "github.com/lxn/win"
+import "github.com/tailscale/win"
 
 // AccState enum defines the state of the window/control
 type AccState int32

--- a/application.go
+++ b/application.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Settings interface {

--- a/bitmap.go
+++ b/bitmap.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const inchesPerMeter float64 = 39.37007874

--- a/boxlayout.go
+++ b/boxlayout.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Orientation byte

--- a/brush.go
+++ b/brush.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type HatchStyle int

--- a/button.go
+++ b/button.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type clickable interface {

--- a/canvas.go
+++ b/canvas.go
@@ -12,7 +12,7 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // DrawText format flags

--- a/checkbox.go
+++ b/checkbox.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"strconv"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type CheckState int

--- a/clipboard.go
+++ b/clipboard.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const clipboardWindowClass = `\o/ Walk_Clipboard_Class \o/`

--- a/combobox.go
+++ b/combobox.go
@@ -15,7 +15,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type ComboBox struct {

--- a/commondialogs.go
+++ b/commondialogs.go
@@ -14,7 +14,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type FileDialog struct {

--- a/composite.go
+++ b/composite.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const compositeWindowClass = `\o/ Walk_Composite_Class \o/`

--- a/container.go
+++ b/container.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Container interface {

--- a/cursor.go
+++ b/cursor.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Cursor interface {

--- a/customwidget.go
+++ b/customwidget.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const customWidgetWindowClass = `\o/ Walk_CustomWidget_Class \o/`

--- a/dateedit.go
+++ b/dateedit.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type DateEdit struct {

--- a/declarative/accessibility.go
+++ b/declarative/accessibility.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 // AccState enum defines the state of the window/control

--- a/declarative/action.go
+++ b/declarative/action.go
@@ -9,7 +9,7 @@ package declarative
 import (
 	"fmt"
 
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type Shortcut struct {

--- a/declarative/brush.go
+++ b/declarative/brush.go
@@ -9,7 +9,7 @@ package declarative
 import (
 	"strconv"
 
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type TransparentBrush struct {

--- a/declarative/builder.go
+++ b/declarative/builder.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 	"gopkg.in/Knetic/govaluate.v3"
 )
 

--- a/declarative/checkbox.go
+++ b/declarative/checkbox.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type CheckBox struct {

--- a/declarative/combobox.go
+++ b/declarative/combobox.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type ComboBox struct {

--- a/declarative/composite.go
+++ b/declarative/composite.go
@@ -7,8 +7,8 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	"github.com/tailscale/win"
 )
 
 type Composite struct {

--- a/declarative/customwidget.go
+++ b/declarative/customwidget.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type PaintMode int

--- a/declarative/databinder.go
+++ b/declarative/databinder.go
@@ -9,7 +9,7 @@ package declarative
 import (
 	"time"
 
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type DataBinder struct {

--- a/declarative/dateedit.go
+++ b/declarative/dateedit.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type DateEdit struct {

--- a/declarative/datelabel.go
+++ b/declarative/datelabel.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type DateLabel struct {

--- a/declarative/dialog.go
+++ b/declarative/dialog.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type Dialog struct {

--- a/declarative/font.go
+++ b/declarative/font.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type Font struct {

--- a/declarative/gradientcomposite.go
+++ b/declarative/gradientcomposite.go
@@ -7,8 +7,8 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	"github.com/tailscale/win"
 )
 
 type GradientComposite struct {

--- a/declarative/groupbox.go
+++ b/declarative/groupbox.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type GroupBox struct {

--- a/declarative/imageview.go
+++ b/declarative/imageview.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type ImageViewMode int

--- a/declarative/interfaces.go
+++ b/declarative/interfaces.go
@@ -9,7 +9,7 @@ package declarative
 import (
 	"path/filepath"
 
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 func tr(source string, context ...string) string {

--- a/declarative/label.go
+++ b/declarative/label.go
@@ -7,8 +7,8 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	"github.com/tailscale/win"
 )
 
 type EllipsisMode int

--- a/declarative/layouts.go
+++ b/declarative/layouts.go
@@ -9,7 +9,7 @@ package declarative
 import (
 	"errors"
 
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type Orientation byte

--- a/declarative/lineedit.go
+++ b/declarative/lineedit.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type CaseMode uint32

--- a/declarative/linklabel.go
+++ b/declarative/linklabel.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type LinkLabel struct {

--- a/declarative/listbox.go
+++ b/declarative/listbox.go
@@ -9,8 +9,8 @@ package declarative
 import (
 	"errors"
 
-	"github.com/lxn/walk"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	"github.com/tailscale/win"
 )
 
 type ListBox struct {

--- a/declarative/mainwindow.go
+++ b/declarative/mainwindow.go
@@ -6,7 +6,7 @@
 
 package declarative
 
-import "github.com/lxn/walk"
+import "github.com/tailscale/walk"
 
 type MainWindow struct {
 	// Window

--- a/declarative/numberedit.go
+++ b/declarative/numberedit.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type NumberEdit struct {

--- a/declarative/numberlabel.go
+++ b/declarative/numberlabel.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type NumberLabel struct {

--- a/declarative/progressbar.go
+++ b/declarative/progressbar.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type ProgressBar struct {

--- a/declarative/pushbutton.go
+++ b/declarative/pushbutton.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type PushButton struct {

--- a/declarative/radiobutton.go
+++ b/declarative/radiobutton.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type RadioButton struct {

--- a/declarative/radiobuttongroup.go
+++ b/declarative/radiobuttongroup.go
@@ -12,7 +12,7 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type RadioButtonGroup struct {

--- a/declarative/radiobuttongroupbox.go
+++ b/declarative/radiobuttongroupbox.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type RadioButtonGroupBox struct {

--- a/declarative/scrollview.go
+++ b/declarative/scrollview.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type ScrollView struct {

--- a/declarative/separator.go
+++ b/declarative/separator.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type HSeparator struct {

--- a/declarative/slider.go
+++ b/declarative/slider.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type Slider struct {

--- a/declarative/spacer.go
+++ b/declarative/spacer.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type HSpacer struct {

--- a/declarative/splitbutton.go
+++ b/declarative/splitbutton.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type SplitButton struct {

--- a/declarative/splitter.go
+++ b/declarative/splitter.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type HSplitter struct {

--- a/declarative/tableview.go
+++ b/declarative/tableview.go
@@ -7,8 +7,8 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	"github.com/tailscale/win"
 )
 
 type TableView struct {

--- a/declarative/tableviewcolumn.go
+++ b/declarative/tableviewcolumn.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type Alignment1D uint

--- a/declarative/tabpage.go
+++ b/declarative/tabpage.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type TabPage struct {

--- a/declarative/tabwidget.go
+++ b/declarative/tabwidget.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type TabWidget struct {

--- a/declarative/textedit.go
+++ b/declarative/textedit.go
@@ -7,8 +7,8 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	"github.com/tailscale/win"
 )
 
 type TextEdit struct {

--- a/declarative/textlabel.go
+++ b/declarative/textlabel.go
@@ -7,8 +7,8 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	"github.com/tailscale/win"
 )
 
 type Alignment2D uint

--- a/declarative/toolbar.go
+++ b/declarative/toolbar.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type ToolBarButtonStyle int

--- a/declarative/toolbutton.go
+++ b/declarative/toolbutton.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type ToolButton struct {

--- a/declarative/treeview.go
+++ b/declarative/treeview.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type TreeView struct {

--- a/declarative/validators.go
+++ b/declarative/validators.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type ValidatorRef struct {

--- a/declarative/webview.go
+++ b/declarative/webview.go
@@ -7,7 +7,7 @@
 package declarative
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type WebView struct {

--- a/dialog.go
+++ b/dialog.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const (

--- a/dropfilesevent.go
+++ b/dropfilesevent.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"syscall"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type dropFilesEventHandlerInfo struct {

--- a/error.go
+++ b/error.go
@@ -13,7 +13,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var (

--- a/examples/actions/actions.go
+++ b/examples/actions/actions.go
@@ -9,8 +9,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 var isSpecialMode = walk.NewMutableCondition()

--- a/examples/clipboard/clipboard.go
+++ b/examples/clipboard/clipboard.go
@@ -9,8 +9,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/databinding/databinding.go
+++ b/examples/databinding/databinding.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 
-	. "github.com/lxn/walk/declarative"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/drawing/drawing.go
+++ b/examples/drawing/drawing.go
@@ -10,8 +10,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/dropfiles/dropfiles.go
+++ b/examples/dropfiles/dropfiles.go
@@ -7,8 +7,8 @@ package main
 import (
 	"strings"
 
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/externalwidgets/externalwidgets.go
+++ b/examples/externalwidgets/externalwidgets.go
@@ -7,10 +7,10 @@ package main
 import (
 	"log"
 
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 
-	. "github.com/lxn/walk/declarative"
-	"github.com/lxn/win"
+	. "github.com/tailscale/walk/declarative"
+	"github.com/tailscale/win"
 )
 
 const myWidgetWindowClass = "MyWidget Class"

--- a/examples/filebrowser/filebrowser.go
+++ b/examples/filebrowser/filebrowser.go
@@ -12,8 +12,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 type Directory struct {

--- a/examples/gradientcomposite/gradientcomposite.go
+++ b/examples/gradientcomposite/gradientcomposite.go
@@ -5,8 +5,8 @@
 package main
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/imageicon/main.go
+++ b/examples/imageicon/main.go
@@ -12,8 +12,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/imageview/imageview.go
+++ b/examples/imageview/imageview.go
@@ -5,8 +5,8 @@
 package main
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/imageviewer/imageviewer.go
+++ b/examples/imageviewer/imageviewer.go
@@ -11,8 +11,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/linklabel/linklabel.go
+++ b/examples/linklabel/linklabel.go
@@ -9,8 +9,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {
@@ -21,7 +21,7 @@ func main() {
 		Children: []Widget{
 			LinkLabel{
 				MaxSize: Size{100, 0},
-				Text:    `I can contain multiple links like <a id="this" href="https://golang.org">this</a> or <a id="that" href="https://github.com/lxn/walk">that one</a>.`,
+				Text:    `I can contain multiple links like <a id="this" href="https://golang.org">this</a> or <a id="that" href="https://github.com/tailscale/walk">that one</a>.`,
 				OnLinkActivated: func(link *walk.LinkLabelLink) {
 					log.Printf("id: '%s', url: '%s'\n", link.Id(), link.URL())
 				},

--- a/examples/listbox/listbox.go
+++ b/examples/listbox/listbox.go
@@ -12,8 +12,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/listbox_ownerdrawing/listbox_ownerdrawing.go
+++ b/examples/listbox_ownerdrawing/listbox_ownerdrawing.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
+	"github.com/tailscale/win"
 )
 
 func main() {

--- a/examples/logview/logview.go
+++ b/examples/logview/logview.go
@@ -10,8 +10,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	"github.com/lxn/win"
+	"github.com/tailscale/walk"
+	"github.com/tailscale/win"
 )
 
 type LogView struct {

--- a/examples/logview/logviewapp.go
+++ b/examples/logview/logviewapp.go
@@ -10,8 +10,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/multiplepages/main.go
+++ b/examples/multiplepages/main.go
@@ -9,8 +9,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/multiplepages/multipagemainwindow.go
+++ b/examples/multiplepages/multipagemainwindow.go
@@ -5,8 +5,8 @@
 package main
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 type MultiPageMainWindowConfig struct {

--- a/examples/notifyicon/notifyicon.go
+++ b/examples/notifyicon/notifyicon.go
@@ -9,7 +9,7 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 func main() {

--- a/examples/progressindicator/dialog_ui.go
+++ b/examples/progressindicator/dialog_ui.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 type myDialogUI struct {

--- a/examples/progressindicator/pi.go
+++ b/examples/progressindicator/pi.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
+	"github.com/tailscale/walk"
 )
 
 func main() {

--- a/examples/radiobutton/radiobutton.go
+++ b/examples/radiobutton/radiobutton.go
@@ -9,7 +9,7 @@ import (
 )
 
 import (
-	. "github.com/lxn/walk/declarative"
+	. "github.com/tailscale/walk/declarative"
 )
 
 type Foo struct {

--- a/examples/settings/settings.go
+++ b/examples/settings/settings.go
@@ -12,8 +12,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/slider/slider.go
+++ b/examples/slider/slider.go
@@ -7,8 +7,8 @@ package main
 import (
 	"log"
 
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/statusbar/statusbar.go
+++ b/examples/statusbar/statusbar.go
@@ -10,8 +10,8 @@ package main
 import (
 	"log"
 
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {

--- a/examples/tableview/tableview.go
+++ b/examples/tableview/tableview.go
@@ -13,8 +13,8 @@ import (
 )
 
 import (
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 type Foo struct {

--- a/examples/webview/webview.go
+++ b/examples/webview/webview.go
@@ -7,8 +7,8 @@ package main
 import (
 	"strings"
 
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 func main() {
@@ -33,7 +33,7 @@ func main() {
 			WebView{
 				AssignTo: &wv,
 				Name:     "wv",
-				URL:      "https://github.com/lxn/walk",
+				URL:      "https://github.com/tailscale/walk",
 			},
 		},
 		Functions: map[string]func(args ...interface{}) (interface{}, error){

--- a/examples/webview_events/webview_events.go
+++ b/examples/webview_events/webview_events.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"strings"
 
-	"github.com/lxn/walk"
-	. "github.com/lxn/walk/declarative"
+	"github.com/tailscale/walk"
+	. "github.com/tailscale/walk/declarative"
 )
 
 type MainWin struct {
@@ -50,7 +50,7 @@ func NewMainWin() (*MainWin, error) {
 			WebView{
 				AssignTo:                  &mainWin.wv,
 				Name:                      "wv",
-				URL:                       "https://github.com/lxn/walk",
+				URL:                       "https://github.com/tailscale/walk",
 				ShortcutsEnabled:          true,
 				NativeContextMenuEnabled:  true,
 				OnNavigating:              mainWin.webView_OnNavigating,

--- a/flowlayout.go
+++ b/flowlayout.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type FlowLayout struct {

--- a/font.go
+++ b/font.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type FontStyle byte

--- a/fontresource.go
+++ b/fontresource.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 	"syscall"
 )
 

--- a/form.go
+++ b/form.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type CloseReason byte

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,7 @@ module github.com/tailscale/walk
 go 1.17
 
 require (
-	github.com/lxn/walk v0.0.0-20210112085537-c389da54e794
-	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
+	github.com/tailscale/win v0.0.0-20221118185520-e8ccca099752
 	golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c
 	gopkg.in/Knetic/govaluate.v3 v3.0.0
-)
-
-replace (
-	github.com/lxn/walk => github.com/tailscale/walk v0.0.0-20220506150313-ed127cfb919a
-	github.com/lxn/win => github.com/tailscale/win v0.0.0-20221118185520-e8ccca099752
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/tailscale/walk v0.0.0-20220506150313-ed127cfb919a h1:uptpnGzRLeSxntDX81sonfvoqxSH54COkJcX14TYWAo=
-github.com/tailscale/walk v0.0.0-20220506150313-ed127cfb919a/go.mod h1:8mDkfXFy+FtezqBBO6mTwoBpW32aetZkrZxBNrdoU3A=
 github.com/tailscale/win v0.0.0-20221118185520-e8ccca099752 h1:HEjbCnclYTqYGERu4RVMkU6cczgpzUd5TQbvT1AStbw=
 github.com/tailscale/win v0.0.0-20221118185520-e8ccca099752/go.mod h1:pW76gHd94DwbTRePyhfsevz9KvQJHBtNT7vZ+TmqBCs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/gradientcomposite.go
+++ b/gradientcomposite.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type GradientComposite struct {

--- a/groupbox.go
+++ b/groupbox.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const groupBoxWindowClass = `\o/ Walk_GroupBox_Class \o/`

--- a/icon.go
+++ b/icon.go
@@ -14,7 +14,7 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // Icon is a bitmap that supports transparency and combining multiple

--- a/image.go
+++ b/image.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Image interface {

--- a/imagelist.go
+++ b/imagelist.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type ImageList struct {

--- a/imageview.go
+++ b/imageview.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"math"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type ImageViewMode int

--- a/keyboard.go
+++ b/keyboard.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Key uint16

--- a/label.go
+++ b/label.go
@@ -6,7 +6,7 @@
 
 package walk
 
-import "github.com/lxn/win"
+import "github.com/tailscale/win"
 
 type EllipsisMode int
 

--- a/layout.go
+++ b/layout.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"sync"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 func createLayoutItemForWidget(widget Widget) LayoutItem {

--- a/lineedit.go
+++ b/lineedit.go
@@ -12,7 +12,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type CaseMode uint32

--- a/linklabel.go
+++ b/linklabel.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type LinkLabel struct {

--- a/listbox.go
+++ b/listbox.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type ListBox struct {

--- a/mainloop_cgo.go
+++ b/mainloop_cgo.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // #include <windows.h>

--- a/mainloop_default.go
+++ b/mainloop_default.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 func (fb *FormBase) mainLoop() int {

--- a/mainwindow.go
+++ b/mainwindow.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const mainWindowWindowClass = `\o/ Walk_MainWindow_Class \o/`

--- a/menu.go
+++ b/menu.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Menu struct {

--- a/messagebox.go
+++ b/messagebox.go
@@ -12,7 +12,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type MsgBoxStyle uint

--- a/metafile.go
+++ b/metafile.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const milimeterPerMeter float64 = 1000.0

--- a/models.go
+++ b/models.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"syscall"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // BindingValueProvider is the interface that a model must implement to support

--- a/mouseevent.go
+++ b/mouseevent.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type MouseButton int

--- a/notifyicon.go
+++ b/notifyicon.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var notifyIcons = make(map[*NotifyIcon]bool)

--- a/numberedit.go
+++ b/numberedit.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const numberEditWindowClass = `\o/ Walk_NumberEdit_Class \o/`

--- a/path.go
+++ b/path.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"syscall"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 func knownFolderPath(id win.CSIDL) (string, error) {

--- a/pen.go
+++ b/pen.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type PenStyle int

--- a/point.go
+++ b/point.go
@@ -6,7 +6,7 @@
 
 package walk
 
-import "github.com/lxn/win"
+import "github.com/tailscale/win"
 
 // Point defines 2D coordinate in 1/96" units ot native pixels.
 type Point struct {

--- a/progressbar.go
+++ b/progressbar.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type ProgressBar struct {

--- a/progressindicator.go
+++ b/progressindicator.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 	"syscall"
 )
 

--- a/pushbutton.go
+++ b/pushbutton.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type PushButton struct {

--- a/radiobutton.go
+++ b/radiobutton.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type RadioButtonGroup struct {

--- a/rectangle.go
+++ b/rectangle.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // Rectangle defines upper left corner with width and height region in 1/96" units, or native

--- a/registry.go
+++ b/registry.go
@@ -12,7 +12,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type RegistryKey struct {

--- a/scrollview.go
+++ b/scrollview.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const scrollViewWindowClass = `\o/ Walk_ScrollView_Class \o/`

--- a/separator.go
+++ b/separator.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Separator struct {

--- a/size.go
+++ b/size.go
@@ -6,7 +6,7 @@
 
 package walk
 
-import "github.com/lxn/win"
+import "github.com/tailscale/win"
 
 // Size defines width and height in 1/96" units or native pixels, or dialog base units.
 //

--- a/slider.go
+++ b/slider.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"strconv"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type Slider struct {

--- a/splitbutton.go
+++ b/splitbutton.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type SplitButton struct {

--- a/splitter.go
+++ b/splitter.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const splitterWindowClass = `\o/ Walk_Splitter_Class \o/`

--- a/splitterhandle.go
+++ b/splitterhandle.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const splitterHandleWindowClass = `\o/ Walk_SplitterHandle_Class \o/`

--- a/splitterlayout.go
+++ b/splitterlayout.go
@@ -9,7 +9,7 @@ package walk
 import (
 	"sort"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type splitterLayout struct {

--- a/static.go
+++ b/static.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const staticWindowClass = `\o/ Walk_Static_Class \o/`

--- a/statusbar.go
+++ b/statusbar.go
@@ -12,7 +12,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // StatusBar is a widget that displays status messages.

--- a/tableview.go
+++ b/tableview.go
@@ -15,7 +15,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const tableViewWindowClass = `\o/ Walk_TableView_Class \o/`

--- a/tableviewcolumn.go
+++ b/tableviewcolumn.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // TableViewColumn represents a column in a TableView.

--- a/tabpage.go
+++ b/tabpage.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const tabPageWindowClass = `\o/ Walk_TabPage_Class \o/`

--- a/tabpagelist.go
+++ b/tabpagelist.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type tabPageListObserver interface {

--- a/tabwidget.go
+++ b/tabwidget.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const tabWidgetWindowClass = `\o/ Walk_TabWidget_Class \o/`

--- a/textedit.go
+++ b/textedit.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type TextEdit struct {

--- a/toolbar.go
+++ b/toolbar.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type ToolBarButtonStyle int

--- a/toolbutton.go
+++ b/toolbutton.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type ToolButton struct {

--- a/tools/ui2walk/ui2walk.go
+++ b/tools/ui2walk/ui2walk.go
@@ -898,7 +898,7 @@ func generateUICode(buf *bytes.Buffer, ui *UI) error {
 		package main
 		
 		import (
-			"github.com/lxn/walk"
+			"github.com/tailscale/walk"
 		)
 		
 		`)
@@ -1070,7 +1070,7 @@ func generateLogicCode(buf *bytes.Buffer, ui *UI) error {
 		`package main
 		
 		import (
-			"github.com/lxn/walk"
+			"github.com/tailscale/walk"
 		)
 		
 		`)

--- a/tooltip.go
+++ b/tooltip.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/bb760416(v=vs.85).aspx says 80,

--- a/tooltiperrorpresenter.go
+++ b/tooltiperrorpresenter.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var ValidationErrorEffect WidgetGraphicsEffect

--- a/treeview.go
+++ b/treeview.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type treeViewItemInfo struct {

--- a/util.go
+++ b/util.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var (

--- a/webview.go
+++ b/webview.go
@@ -13,7 +13,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 const webViewWindowClass = `\o/ Walk_WebView_Class \o/`

--- a/webview_dwebbrowserevents2.go
+++ b/webview_dwebbrowserevents2.go
@@ -14,7 +14,7 @@ import (
 import (
 	"time"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var webViewDWebBrowserEvents2Vtbl *win.DWebBrowserEvents2Vtbl

--- a/webview_events.go
+++ b/webview_events.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type WebViewNavigatingEventData struct {

--- a/webview_idochostuihandler.go
+++ b/webview_idochostuihandler.go
@@ -12,7 +12,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var webViewIDocHostUIHandlerVtbl *win.IDocHostUIHandlerVtbl

--- a/webview_ioleclientsite.go
+++ b/webview_ioleclientsite.go
@@ -12,7 +12,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var webViewIOleClientSiteVtbl *win.IOleClientSiteVtbl

--- a/webview_ioleinplaceframe.go
+++ b/webview_ioleinplaceframe.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var webViewIOleInPlaceFrameVtbl *win.IOleInPlaceFrameVtbl

--- a/webview_ioleinplacesite.go
+++ b/webview_ioleinplacesite.go
@@ -12,7 +12,7 @@ import (
 )
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 var webViewIOleInPlaceSiteVtbl *win.IOleInPlaceSiteVtbl

--- a/widget.go
+++ b/widget.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // LayoutFlags specify how a Widget wants to be treated when used with a Layout.

--- a/widgetlist.go
+++ b/widgetlist.go
@@ -7,7 +7,7 @@
 package walk
 
 import (
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 type widgetListObserver interface {

--- a/window.go
+++ b/window.go
@@ -17,7 +17,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // App-specific message ids for internal use in Walk.

--- a/windowgroup.go
+++ b/windowgroup.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/lxn/win"
+	"github.com/tailscale/win"
 )
 
 // The global window group manager instance.


### PR DESCRIPTION
I need to make some pretty big changes to `walk`. Given that upstream has not merged a PR since Feb 2021, I think we have to accept that this repo will be a little less temporary than we thought.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>