### PR TITLE
action.go, actionlist.go, idalloc, menu.go: fix menu ID allocation an…

### DIFF
--- a/idalloc/idalloc.go
+++ b/idalloc/idalloc.go
@@ -1,0 +1,89 @@
+// Copyright 2022 Tailscale Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package idalloc provides a simple bitmap allocator for ID values.
+package idalloc
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/bits"
+)
+
+// IDMaxLimit is the maximum possible ID value that could be returned by an
+// IDAllocator.
+const IDMaxLimit = math.MaxUint32
+
+// ErrIDsExhausted is returned when an IDAllocator is unable to fulfill an
+// allocation request.
+var ErrIDsExhausted = errors.New("no more IDs available")
+
+// IDAllocator is an allocator for ID values. It is implemented using a bitmap
+// that is grown as necessary.
+type IDAllocator struct {
+	bits      []uint
+	maxBlocks uint32
+}
+
+const initialSize = uint32(64)
+
+// New creates a new IDAllocator that may allocate up to numIDs values. numIDs
+// must be a multiple of 64.
+func New(numIDs uint32) IDAllocator {
+	// For this check we use initialSize (64) instead of bits.UintSize so that we
+	// can be consistent between CPU architectures.
+	if numIDs == 0 || numIDs%initialSize != 0 {
+		panic(fmt.Sprintf("numIDs must be non-zero and divisible by %d", initialSize))
+	}
+
+	numBlocks := (initialSize + bits.UintSize - 1) / bits.UintSize
+	return IDAllocator{
+		bits:      make([]uint, numBlocks),
+		maxBlocks: (numIDs + bits.UintSize - 1) / bits.UintSize,
+	}
+}
+
+// Allocate finds an unused ID, sets it as used, and returns its value.
+// If the IDAllocator is full and there are no more IDs available, id
+// will be set to IDMaxLimit and err will be set to ErrIDsExhausted.
+func (a *IDAllocator) Allocate() (id uint32, err error) {
+	i := uint32(0)
+	for {
+		curBlock := a.bits[i]
+		if curBlock != ^uint(0) {
+			bb := uint32(bits.TrailingZeros(^curBlock))
+			a.bits[i] = curBlock | (uint(1) << bb)
+			return uint32(i*bits.UintSize + bb), nil
+		}
+
+		i++
+		if i == uint32(len(a.bits)) && !a.grow() {
+			return IDMaxLimit, ErrIDsExhausted
+		}
+	}
+}
+
+// Free marks id as unused. id must have been previously returned by a
+// successful call to Allocate.
+func (a *IDAllocator) Free(id uint32) {
+	i, mask := id/bits.UintSize, uint(1)<<(id%bits.UintSize)
+	a.bits[i] &= ^mask
+}
+
+func (a *IDAllocator) grow() bool {
+	n, m := uint32(len(a.bits)), a.maxBlocks
+	if n >= m {
+		return false
+	}
+
+	// Try to double the size, but if that would exceed our maximum then just
+	// allocate up to the max.
+	if 2*n > m {
+		n = m - n
+	}
+
+	a.bits = append(a.bits, make([]uint, n)...)
+	return true
+}

--- a/idalloc/idalloc_test.go
+++ b/idalloc/idalloc_test.go
@@ -1,0 +1,114 @@
+// Copyright 2022 Tailscale Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package idalloc
+
+import (
+	"math/bits"
+	"testing"
+)
+
+func TestIDAllocator(t *testing.T) {
+	set := map[uint32]struct{}{}
+
+	alloc := New(192)
+	for i := 0; i < 64; i++ {
+		bit, err := alloc.Allocate()
+		if err != nil {
+			t.Errorf("Allocate error: got %v, want nil", err)
+		}
+		if _, ok := set[bit]; ok {
+			t.Errorf("Unexpected duplicate value %d", bit)
+		}
+		set[bit] = struct{}{}
+	}
+
+	if uint32(len(alloc.bits)) != initialSize/bits.UintSize {
+		t.Errorf("Unexpected length for bits, got %d want %d", len(alloc.bits), initialSize/bits.UintSize)
+	}
+
+	for i, v := range alloc.bits {
+		if v != ^uint(0) {
+			t.Errorf("Unexpected bits in block %d, got %d want %d", i, v, ^uint(0))
+		}
+	}
+
+	alloc.Free(62)
+	bit, err := alloc.Allocate()
+	if err != nil {
+		t.Errorf("Allocate error: got %v, want nil", err)
+	}
+	if bit != 62 {
+		t.Errorf("Unexpected allocation: got %d, want %d", bit, 62)
+	}
+
+	bit, err = alloc.Allocate()
+	if err != nil {
+		t.Errorf("Allocate error: got %v, want nil", err)
+	}
+	if bit != 64 {
+		t.Errorf("Unexpected allocation: got %d, want %d", bit, 64)
+	}
+
+	left := alloc.maxBlocks*bits.UintSize - (bit + 1)
+	for i := uint32(0); i < left; i++ {
+		bit, err := alloc.Allocate()
+		if err != nil {
+			t.Errorf("Allocate error: got %v, want nil", err)
+		}
+		if _, ok := set[bit]; ok {
+			t.Errorf("Unexpected duplicate value %d", bit)
+		}
+		set[bit] = struct{}{}
+	}
+
+	for i, v := range alloc.bits {
+		if v != ^uint(0) {
+			t.Errorf("Unexpected bits in block %d, got %d, want %d", i, v, ^uint(0))
+		}
+	}
+
+	bit, err = alloc.Allocate()
+	if bit != IDMaxLimit {
+		t.Errorf("Unexpected value for bit, got %d, want %d", bit, IDMaxLimit)
+	}
+	if err != ErrIDsExhausted {
+		t.Errorf("Unexpected value for err, got %v, want %v", err, ErrIDsExhausted)
+	}
+
+	p := func() (result interface{}) {
+		defer func() {
+			result = recover()
+		}()
+		alloc.Free(512)
+		return result
+	}
+	if p == nil {
+		t.Errorf("Expected panic but did not")
+	}
+}
+
+func TestBadMaxValue(t *testing.T) {
+	p := func() (result interface{}) {
+		defer func() {
+			result = recover()
+		}()
+		New(0)
+		return result
+	}()
+	if p == nil {
+		t.Errorf("Expected panic but did not")
+	}
+
+	p = func() (result interface{}) {
+		defer func() {
+			result = recover()
+		}()
+		New(127)
+		return result
+	}()
+	if p == nil {
+		t.Errorf("Expected panic but did not")
+	}
+}

--- a/menu.go
+++ b/menu.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package walk
@@ -186,22 +187,9 @@ func (m *Menu) onActionChanged(action *Action) error {
 	}
 
 	if action.Exclusive() && action.Checked() {
-		var first, last int
-
-		index := m.actions.Index(action)
-
-		for i := index; i >= 0; i-- {
-			first = i
-			if !m.actions.At(i).Exclusive() {
-				break
-			}
-		}
-
-		for i := index; i < m.actions.Len(); i++ {
-			last = i
-			if !m.actions.At(i).Exclusive() {
-				break
-			}
+		first, last, index, err := m.actions.positionsForExclusiveCheck(action)
+		if err != nil {
+			return err
 		}
 
 		if !win.CheckMenuRadioItem(m.hMenu, uint32(first), uint32(last), uint32(index), win.MF_BYPOSITION) {


### PR DESCRIPTION
…d bug in radio menu items

This patch takes care of two issues with menus:

* We add a simple bitmap allocator for menu item IDs so that they may be reused. This allows us to eliminate any hacks we were using to retain menu items and avoid consuming all available IDs. Those hacks break radio menu items, so eliminating them will allow us to move forward there.
* We fix a bug in the code that computes indexes for the call to win.CheckMenuRadioItem: that code was computing indexes that included actions that were not visible. Since hidden actions are not provided to the Windows menu APIs, those indexes would be invalid when passed to Win32, and the API call would fail.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>