### PR TITLE
Add convenience methods for iterating over an action list

### DIFF
--- a/actionlist.go
+++ b/actionlist.go
@@ -239,3 +239,26 @@ func (l *ActionList) updateSeparatorVisibility() error {
 
 	return nil
 }
+
+// forEach iterates through each action in l, calling f for each one. If f
+// returns false, the iteration is aborted.
+func (l *ActionList) forEach(f func(*Action) bool) {
+	for _, a := range l.actions {
+		if !f(a) {
+			break
+		}
+	}
+}
+
+// forEach iterates through each action in l, calling f for each visible action.
+// If f returns false, the iteration is aborted.
+func (l *ActionList) forEachVisible(f func(*Action) bool) {
+	for _, a := range l.actions {
+		if !a.Visible() {
+			continue
+		}
+		if !f(a) {
+			break
+		}
+	}
+}


### PR DESCRIPTION
This patch adds `forEach` and `forEachVisible` as helpers for iterating over an action list, mainly so that `func`s can be passed in that contain `defer` statements.
