### PR TITLE
canvas.go: rename Canvas.doNotDispose to improve clarity and add Canv…

### DIFF
--- a/customwidget.go
+++ b/customwidget.go
@@ -190,7 +190,7 @@ func (cw *CustomWidget) bufferedPaint(canvas *Canvas, updateBounds Rectangle) er
 	}
 	defer win.DeleteDC(hdc)
 
-	buffered := Canvas{hdc: hdc, doNotDispose: true}
+	buffered := Canvas{hdc: hdc, doNotDisposeDC: true}
 	if _, err := buffered.init(); err != nil {
 		return err
 	}


### PR DESCRIPTION
…as.withFont

The withFont helper method is for use in a later patch. We want the theme to decide text color but want to set the font ourselves.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>