### PR TITLE
add additional helpers for conversions between types

### DIFF
--- a/rectangle.go
+++ b/rectangle.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package walk
@@ -18,6 +19,11 @@ type Rectangle struct {
 
 func (r Rectangle) IsZero() bool {
 	return r.X == 0 && r.Y == 0 && r.Width == 0 && r.Height == 0
+}
+
+// RectangleFromRECT converts r from a win.RECT to a Rectangle.
+func RectangleFromRECT(r win.RECT) Rectangle {
+	return rectangleFromRECT(r)
 }
 
 func rectangleFromRECT(r win.RECT) Rectangle {

--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package walk
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"github.com/tailscale/win"
+	"golang.org/x/exp/constraints"
 )
 
 var (
@@ -514,22 +516,27 @@ func dpiForHDC(hdc win.HDC) int {
 }
 
 // IntFrom96DPI converts from 1/96" units to native pixels.
-func IntFrom96DPI(value, dpi int) int {
+func IntFrom96DPI[I constraints.Integer](value I, dpi int) I {
 	return scaleInt(value, float64(dpi)/96.0)
 }
 
 // IntTo96DPI converts from native pixels to 1/96" units.
-func IntTo96DPI(value, dpi int) int {
+func IntTo96DPI[I constraints.Integer](value I, dpi int) I {
 	return scaleInt(value, 96.0/float64(dpi))
 }
 
-func scaleInt(value int, scale float64) int {
-	return int(math.Round(float64(value) * scale))
+func scaleInt[I constraints.Integer](value I, scale float64) I {
+	return I(math.Round(float64(value) * scale))
 }
 
 // MarginsFrom96DPI converts from 1/96" units to native pixels.
 func MarginsFrom96DPI(value Margins, dpi int) Margins {
 	return scaleMargins(value, float64(dpi)/96.0)
+}
+
+// MARGINSFrom96DPI converts from 1/96" units to native pixels.
+func MARGINSFrom96DPI(value win.MARGINS, dpi int) win.MARGINS {
+	return scaleMARGINS(value, float64(dpi)/96.0)
 }
 
 // MarginsTo96DPI converts from native pixels to 1/96" units.
@@ -543,6 +550,15 @@ func scaleMargins(value Margins, scale float64) Margins {
 		VNear: scaleInt(value.VNear, scale),
 		HFar:  scaleInt(value.HFar, scale),
 		VFar:  scaleInt(value.VFar, scale),
+	}
+}
+
+func scaleMARGINS(value win.MARGINS, scale float64) win.MARGINS {
+	return win.MARGINS{
+		LeftWidth:    scaleInt(value.LeftWidth, scale),
+		RightWidth:   scaleInt(value.RightWidth, scale),
+		TopHeight:    scaleInt(value.TopHeight, scale),
+		BottomHeight: scaleInt(value.BottomHeight, scale),
 	}
 }
 
@@ -587,6 +603,11 @@ func SizeFrom96DPI(value Size, dpi int) Size {
 	return scaleSize(value, float64(dpi)/96.0)
 }
 
+// SIZEFrom96DPI converts from 1/96" units to native pixels.
+func SIZEFrom96DPI(value win.SIZE, dpi int) win.SIZE {
+	return scaleSIZE(value, float64(dpi)/96.0)
+}
+
 // SizeTo96DPI converts from native pixels to 1/96" units.
 func SizeTo96DPI(value Size, dpi int) Size {
 	return scaleSize(value, 96.0/float64(dpi))
@@ -597,4 +618,35 @@ func scaleSize(value Size, scale float64) Size {
 		Width:  scaleInt(value.Width, scale),
 		Height: scaleInt(value.Height, scale),
 	}
+}
+
+func scaleSIZE(value win.SIZE, scale float64) win.SIZE {
+	return win.SIZE{
+		CX: scaleInt(value.CX, scale),
+		CY: scaleInt(value.CY, scale),
+	}
+}
+
+// Max returns the largest value in values. It panics if len(values) == 0.
+func Max[O constraints.Ordered](values ...O) (ret O) {
+	ret = values[0]
+	for _, v := range values[1:] {
+		if v > ret {
+			ret = v
+		}
+	}
+
+	return ret
+}
+
+// Min returns the smallest value in values. It panics if len(values) == 0.
+func Min[O constraints.Ordered](values ...O) (ret O) {
+	ret = values[0]
+	for _, v := range values[1:] {
+		if v < ret {
+			ret = v
+		}
+	}
+
+	return ret
 }

--- a/window.go
+++ b/window.go
@@ -1047,6 +1047,11 @@ func (wb *WindowBase) IntFrom96DPI(value int) int {
 	return IntFrom96DPI(value, wb.DPI())
 }
 
+// Int32From96DPI converts from 1/96" units to native pixels.
+func (wb *WindowBase) Int32From96DPI(value int32) int32 {
+	return IntFrom96DPI(value, wb.DPI())
+}
+
 // IntTo96DPI converts from native pixels to 1/96" units.
 func (wb *WindowBase) IntTo96DPI(value int) int {
 	return IntTo96DPI(value, wb.DPI())
@@ -1055,6 +1060,11 @@ func (wb *WindowBase) IntTo96DPI(value int) int {
 // MarginsFrom96DPI converts from 1/96" units to native pixels.
 func (wb *WindowBase) MarginsFrom96DPI(value Margins) Margins {
 	return MarginsFrom96DPI(value, wb.DPI())
+}
+
+// MARGINSFrom96DPI converts from 1/96" units to native pixels.
+func (wb *WindowBase) MARGINSFrom96DPI(value win.MARGINS) win.MARGINS {
+	return MARGINSFrom96DPI(value, wb.DPI())
 }
 
 // MarginsTo96DPI converts from native pixels to 1/96" units.


### PR DESCRIPTION
Both for scaling between DPIs and converting between win and walk types.

Signed-off-by: Aaron Klotz <aaron@tailscale.com>