### PR TITLE
improvements to menu resolution and notification icons

### DIFF
--- a/form.go
+++ b/form.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package walk
@@ -885,8 +886,10 @@ func (fb *FormBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 		}
 
 	case taskbarCreatedMsgId:
+		// Invalidate all NotifyIcon IDs by replacing the map, then re-add them.
+		notifyIconIDs = make(map[uint16]*NotifyIcon)
 		for ni := range notifyIcons {
-			ni.readdToTaskbar()
+			ni.reAddToTaskbar()
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/dblohm7/wingoes v0.0.0-20230131214643-2b26ab7fb5f9
-	github.com/tailscale/win v0.0.0-20230202211146-fd21cc0d8ef1
+	github.com/tailscale/win v0.0.0-20230210225258-ad93eed16885
 	golang.org/x/exp v0.0.0-20230127140709-cafedaf64729
 	golang.org/x/sys v0.4.0
 	gopkg.in/Knetic/govaluate.v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/dblohm7/wingoes v0.0.0-20230131214643-2b26ab7fb5f9 h1:BHpX4mgaPLK+6K0ByiQ3fJH9ZrwmHfPJWPIO3et9j6g=
 github.com/dblohm7/wingoes v0.0.0-20230131214643-2b26ab7fb5f9/go.mod h1:54MIJVGBIdbHuav7/YRAAhRxZvpEV9Z9p6jCKPLJ2lw=
-github.com/tailscale/win v0.0.0-20230202211146-fd21cc0d8ef1 h1:Qzkl7Vs652OThl9rrvKt+a0mLXoGA/qVzXQIHL7XY4Q=
-github.com/tailscale/win v0.0.0-20230202211146-fd21cc0d8ef1/go.mod h1:oDwVI4EaMwxWuFslkViCEla7dT7IahdN3SKrpo7g6R0=
+github.com/tailscale/win v0.0.0-20230210225258-ad93eed16885 h1:3aDepVQXknGFOsH3fk3O4ua0+Wh3VkUv+lrqJ0SHd+8=
+github.com/tailscale/win v0.0.0-20230210225258-ad93eed16885/go.mod h1:oDwVI4EaMwxWuFslkViCEla7dT7IahdN3SKrpo7g6R0=
 golang.org/x/exp v0.0.0-20230127140709-cafedaf64729 h1:H2kBA039yqxDv2DScpuC0knhZXO6Evfmt7mN8sGMh/4=
 golang.org/x/exp v0.0.0-20230127140709-cafedaf64729/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=

--- a/mainwindow.go
+++ b/mainwindow.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package walk
@@ -241,9 +242,6 @@ func (mw *MainWindow) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 		if mw.statusBar.BoundsPixels() != bounds {
 			mw.statusBar.SetBoundsPixels(bounds)
 		}
-
-	case win.WM_INITMENUPOPUP:
-		mw.menu.updateItemsWithImageForWindow(mw)
 	}
 
 	return mw.FormBase.WndProc(hwnd, msg, wParam, lParam)

--- a/proceedevent.go
+++ b/proceedevent.go
@@ -1,0 +1,85 @@
+// Copyright 2023 Tailscale Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package walk
+
+type proceedEventHandlerInfo struct {
+	handler ProceedEventHandler
+	once    bool
+}
+
+// ProceedEventHandler is a func that should return true to proceed past the
+// event, or false to abort.
+type ProceedEventHandler func() bool
+
+// ProceedEvent is an event where, if any of its handlers return false, its
+// publisher should not proceed further past the event. Note that once a given
+// handler returns false, the event is immediately aborted; no additional
+// handlers are run.
+type ProceedEvent struct {
+	handlers []proceedEventHandlerInfo
+}
+
+// Attach adds handler to e and will be invoked when the event associated with
+// e is triggered. It returns an integral handle to the event that may be used
+// with Detach.
+func (e *ProceedEvent) Attach(handler ProceedEventHandler) int {
+	handlerInfo := proceedEventHandlerInfo{handler, false}
+
+	for i, h := range e.handlers {
+		if h.handler == nil {
+			e.handlers[i] = handlerInfo
+			return i
+		}
+	}
+
+	e.handlers = append(e.handlers, handlerInfo)
+
+	return len(e.handlers) - 1
+}
+
+// Detach removes the handler specified by handle, which was obtained as the
+// result of a call to Attach.
+func (e *ProceedEvent) Detach(handle int) {
+	e.handlers[handle].handler = nil
+}
+
+// Once is similar to Attach, except that handler is attached as a "one-shot"
+// occurrence; handler will automatically be detached after its first invocation.
+func (e *ProceedEvent) Once(handler ProceedEventHandler) {
+	i := e.Attach(handler)
+	e.handlers[i].once = true
+}
+
+// ProceedEventPublisher is the event publisher used by any code that supports
+// ProceedEvent.
+type ProceedEventPublisher struct {
+	event ProceedEvent
+}
+
+// Event obtains a pointer to the ProceedEvent associated with p.
+func (p *ProceedEventPublisher) Event() *ProceedEvent {
+	return &p.event
+}
+
+// Publish dispatches the event to all registered handlers. The first handler
+// to return false will abort event dispatch and Publish will return false.
+// Otherwise, Publish returns true.
+func (p *ProceedEventPublisher) Publish() bool {
+	for i, h := range p.event.handlers {
+		if h.handler != nil {
+			proceed := h.handler()
+
+			if h.once {
+				p.event.Detach(i)
+			}
+
+			if !proceed {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/toolbar.go
+++ b/toolbar.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package walk
@@ -294,8 +295,6 @@ func (tb *ToolBar) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) ui
 				if !win.ClientToScreen(tb.hWnd, &p) {
 					break
 				}
-
-				action.menu.updateItemsWithImageForWindow(tb)
 
 				win.TrackPopupMenuEx(
 					action.menu.hMenu,

--- a/util.go
+++ b/util.go
@@ -650,3 +650,8 @@ func Min[O constraints.Ordered](values ...O) (ret O) {
 
 	return ret
 }
+
+func ptInRect(pt win.POINT, rect win.RECT) bool {
+	// win.RECT Left and Top are inclusive, Right and Bottom are exclusive
+	return pt.X >= rect.Left && pt.X < rect.Right && pt.Y >= rect.Top && pt.Y < rect.Bottom
+}

--- a/window.go
+++ b/window.go
@@ -2496,8 +2496,6 @@ func (wb *WindowBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 				y = int32(pt.Y)
 			}
 
-			contextMenu.updateItemsWithImageForWindow(wb.window)
-
 			win.TrackPopupMenuEx(
 				contextMenu.hMenu,
 				win.TPM_NOANIMATION,
@@ -2539,6 +2537,12 @@ func (wb *WindowBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 		wb.boundsChangedPublisher.Publish()
 
 		if nws, ok := wb.window.(interface{ NeedsWmSize() bool }); !ok || !nws.NeedsWmSize() {
+			return 0
+		}
+
+	case win.WM_INITMENUPOPUP:
+		if m := resolveMenu(win.HMENU(wParam)); m != nil {
+			m.onInitPopup(wb)
 			return 0
 		}
 


### PR DESCRIPTION
1. We change Menu constructors to set the menu's DwMenuData field to contain a pointer to the Menu itself.
2. We add a resolveMenu function that, given a HMENU, can obtain the DwMenuData field set in (1) and use that to resolve the *Menu.
3. This allows us to be smarter in our window procedures: we add a WM_INITMENUPOPUP to WindowBase which can resolve and dispatch to any Menu. With this code in place, we remove code in window.go, toolbar.go, and mainwindow.go that did the same thing in a more roundabout way.
4. We add initPopupPublisher to Menu which allows the app to receive an event notification when the menu is going to be shown imminently.
5. We rename (*Menu).updateItemsWithImageForWindow to (*Menu).updateItemsForWindow, as future PRs will use that method for more things than just images.
6. We add a new event type, ProceedEvent, which may be used by an application to signal to the event publisher whether or not it should proceed.
7. We add a ProceedEvent to notification icons: ShowContextMenu will be called just prior to walk initiating a context menu; if any event handlers return false, then the context menu will not be shown.
8. We make some changes to how NotifyIcon handles messages to make it friendlier to keyboard navigation. In particular, we request the coordinates of the notification icon from the shell, and use those to determine the postition of the popup menu. We only use the mouse coordinates as a fallback. We also remove a redundant SendMessage call; WM_CONTEXTMENU messages are always sent on modern Windows, so that call is redundant.
9. We update our reference to tailscale/win to pick up the new API definition for Shell_NotifyIconGetRect.

Updates https://github.com/tailscale/tailscale/issues/4993

Signed-off-by: Aaron Klotz <aaron@tailscale.com>