### PR TITLE
rename DefaultOwnerDrawHandler to DefaultActionOwnerDrawHandler

### DIFF
--- a/bufferedpaint.go
+++ b/bufferedpaint.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
+// +build windows
+
 package walk
 
 import (

--- a/gdiplus.go
+++ b/gdiplus.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
+// +build windows
+
 package walk
 
 import (

--- a/menu.go
+++ b/menu.go
@@ -175,7 +175,7 @@ func (m *Menu) updateItemsForWindow(window Window) {
 		// If we need accelerator space, then we need to measure each item's
 		// shortcut text.
 		// If we have any owner-drawn items, any remaining actions that are not
-		// owner-drawn must be set to owner-drawn via DefaultOwnerDrawHandler.
+		// owner-drawn must be set to owner-drawn via DefaultActionOwnerDrawHandler.
 		// Failure to do so would result in non-owner-drawn items being rendered
 		// without any theming whatsoever.
 		m.actions.forEach(func(a *Action) bool {
@@ -185,7 +185,7 @@ func (m *Menu) updateItemsForWindow(window Window) {
 			if a.OwnerDraw() {
 				return true
 			}
-			a.ownerDrawInfo = newOwnerDrawnMenuItemInfo(a, DefaultOwnerDrawHandler)
+			a.ownerDrawInfo = newOwnerDrawnMenuItemInfo(a, DefaultActionOwnerDrawHandler)
 			a.ownerDrawInfo.sharedMetrics = sm
 			a.ownerDrawInfo.perMenuMetrics = &m.perMenuMetrics
 			m.onActionChanged(a)

--- a/menuownerdraw.go
+++ b/menuownerdraw.go
@@ -15,9 +15,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// DefaultOwnerDrawHandler is the ActionOwnerDrawHandler used by owner-drawn
+// DefaultActionOwnerDrawHandler is the ActionOwnerDrawHandler used by owner-drawn
 // menu items for emulating the way themed menu items are drawn by the system.
-var DefaultOwnerDrawHandler defaultOwnerDrawHandler
+var DefaultActionOwnerDrawHandler defaultActionOwnerDrawHandler
 
 // MenuItemMeasureContext is the data passed into an ActionOwnerDrawHandler's
 // OnMeasure method to facilitate measurement of an owner-draw menu item.
@@ -684,10 +684,10 @@ func (odi *ownerDrawnMenuItemInfo) Dispose() {
 	odi.perMenuMetrics = nil
 }
 
-type defaultOwnerDrawHandler struct{}
+type defaultActionOwnerDrawHandler struct{}
 
 // OnMeasure by default just measures the extents of the menu text.
-func (defaultOwnerDrawHandler) OnMeasure(action *Action, mctx *MenuItemMeasureContext) (widthPixels, heightPixels uint32) {
+func (defaultActionOwnerDrawHandler) OnMeasure(action *Action, mctx *MenuItemMeasureContext) (widthPixels, heightPixels uint32) {
 	extent, err := mctx.Theme.textExtent(mctx.Canvas, mctx.ThemeFont, win.MENU_POPUPITEM, 0, action.Text(), win.DT_LEFT|win.DT_SINGLELINE)
 	if err == nil {
 		widthPixels = uint32(extent.CX)
@@ -698,7 +698,7 @@ func (defaultOwnerDrawHandler) OnMeasure(action *Action, mctx *MenuItemMeasureCo
 }
 
 // OnDraw by default draws both the menu text and the accelerator text, if any.
-func (defaultOwnerDrawHandler) OnDraw(action *Action, dctx *MenuItemDrawContext) {
+func (defaultActionOwnerDrawHandler) OnDraw(action *Action, dctx *MenuItemDrawContext) {
 	flags := uint32(win.DT_LEFT | win.DT_SINGLELINE)
 	if (dctx.State & win.ODS_NOACCEL) != 0 {
 		flags |= win.DT_HIDEPREFIX

--- a/proceedevent.go
+++ b/proceedevent.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
+// +build windows
+
 package walk
 
 type proceedEventHandlerInfo struct {

--- a/theme.go
+++ b/theme.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
+// +build windows
+
 package walk
 
 import (


### PR DESCRIPTION
This better reflects the purpose of the variable, which is specific to menus. I also added some missing go:build directives.