### PR TITLE
menuownerdraw.go: don't strip ampersands out of a11y text

### DIFF
--- a/gdiplus.go
+++ b/gdiplus.go
@@ -210,7 +210,7 @@ func (g *GDIPlusCanvas) ResetClip() error {
 
 // SetClipPath adds path to g's clipping region. combineMode specifies how the
 // path should be combined with the existing clipping region. For more
-// information about the semanics of combineMode, consult the [Microsoft documentation].
+// information about the semantics of combineMode, consult the [Microsoft documentation].
 //
 // [Microsoft documentation]: https://web.archive.org/web/20230206194140/https://learn.microsoft.com/en-us/windows/win32/api/gdiplusenums/ne-gdiplusenums-combinemode
 func (g *GDIPlusCanvas) SetClipPath(path *GDIPlusPath, combineMode win.CombineMode) error {

--- a/menuownerdraw_test.go
+++ b/menuownerdraw_test.go
@@ -13,17 +13,16 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func TestStripMnemonic(t *testing.T) {
+func TestFindExplicitMnemonic(t *testing.T) {
 	testCases := []struct {
 		text    string
-		want    string
 		wantKey Key
 	}{
-		{"", "", 0},
-		{"Law 'N' Order", "Law 'N' Order", 0},
-		{"Law && Order", "Law & Order", 0},
-		{"Law && &Order", "Law & Order", KeyO},
-		{"&Law && &Order && Bacon", "Law & Order & Bacon", KeyL},
+		{"", 0},
+		{"Law 'N' Order", 0},
+		{"Law && Order", 0},
+		{"Law && &Order", KeyO},
+		{"&Law && &Order && Bacon", KeyL},
 	}
 
 	for _, c := range testCases {
@@ -31,11 +30,7 @@ func TestStripMnemonic(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UTF16FromString error %v", err)
 		}
-		k, s := stripMnemonic(utext)
-		got := windows.UTF16ToString(s)
-		if got != c.want {
-			t.Errorf("stripped text for %q got %q, want %q", c.text, got, c.want)
-		}
+		k := findExplicitMnemonic(utext)
 		if k != c.wantKey {
 			t.Errorf("key for %q got 0x%02X, want 0x%02X", c.text, k, c.wantKey)
 		}


### PR DESCRIPTION
Testing has shown that Windows wants the ampersands to be included inside the a11y text. We still need to discover any mnemonic in order to be able to properly respond to it, however we shouldn't strip them.

I also fixed up a couple of typos here and there.