### PR TITLE
menu.go: only redraw the menu bar when the menu represents the menu bar

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -382,7 +382,7 @@ func (m *Menu) removeAction(action *Action, visibleChanged bool) error {
 
 func (m *Menu) ensureMenuBarRedrawn() {
 	if m.window != nil {
-		if mw, ok := m.window.(*MainWindow); ok && mw != nil {
+		if mw, ok := m.window.(*MainWindow); ok && mw.menu == m {
 			win.DrawMenuBar(mw.Handle())
 		}
 	}


### PR DESCRIPTION
As is, this code wastes a bunch of time repeatedly attempting to redraw the menu bar, even if the current menu is a context menu.

We simply add a check to ensure that the current Menu is the main window's top-level menu before issuing the redraw request.