### PR TITLE
menu.go, window.go: always call win.DrawMenuBar, but only do so once …

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -133,6 +133,7 @@ func (m *Menu) onInitPopup(window Window) {
 	m.initPopupPublisher.Publish()
 	m.perMenuMetrics.reset()
 	m.updateItemsForWindow(window)
+	window.AsWindowBase().redrawMenuBar()
 }
 
 func (m *Menu) Actions() *ActionList {
@@ -309,6 +310,8 @@ func (m *Menu) onActionChanged(action *Action) error {
 		}
 	}
 
+	m.ensureMenuBarRedrawn()
+
 	return nil
 }
 
@@ -383,8 +386,13 @@ func (m *Menu) removeAction(action *Action, visibleChanged bool) error {
 func (m *Menu) ensureMenuBarRedrawn() {
 	if m.window != nil {
 		if mw, ok := m.window.(*MainWindow); ok && mw.menu == m {
+			// If m is the top-level menu belonging to a MainWindow, redraw it immediately.
 			win.DrawMenuBar(mw.Handle())
+			return
 		}
+
+		// Otherwise we redraw the menu bar lazily when a popup menu is shown.
+		m.window.AsWindowBase().invalidateMenuBar()
 	}
 }
 

--- a/window.go
+++ b/window.go
@@ -448,6 +448,7 @@ type WindowBase struct {
 	suspended                 bool
 	visible                   bool
 	enabled                   bool
+	needDrawMenuBar           bool
 	acc                       *Accessibility
 	themes                    map[string]*Theme
 	menuSharedMetrics96DPI    *menuSharedMetrics
@@ -2381,6 +2382,19 @@ func (wb *WindowBase) menuSharedMetrics() *menuSharedMetrics {
 	return dpicache.InstanceForDPI(wb.menuSharedMetrics96DPI, wb.DPI())
 }
 
+func (wb *WindowBase) invalidateMenuBar() {
+	wb.needDrawMenuBar = true
+}
+
+func (wb *WindowBase) redrawMenuBar() {
+	if !wb.needDrawMenuBar {
+		return
+	}
+
+	wb.needDrawMenuBar = false
+	win.DrawMenuBar(wb.hWnd)
+}
+
 // WndProc is the window procedure of the window.
 //
 // When implementing your own WndProc to add or modify behavior, call the
@@ -2553,7 +2567,7 @@ func (wb *WindowBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 
 	case win.WM_INITMENUPOPUP:
 		if m := resolveMenu(win.HMENU(wParam)); m != nil {
-			m.onInitPopup(wb)
+			m.onInitPopup(wb.window)
 			return 0
 		}
 


### PR DESCRIPTION
…for menus that are not the main menu

Apparently some RDP connections are not drawing context menus without HMENU mutations being followed by an explicit call to win.DrawMenuBar even though context menus are not part of a window's menu bar.

Originally walk was redrawing the menu bar after every single modification to an HMENU, which was a performance disaster that scaled linearly with the number of menu items in the menu. (Add 200 machines to the device menu? Walk would repaint the menu bar 200 times.) In a previous PR I changed this to only redraw the menu bar for modifications to a menu when that menu is acutally part of the menu bar itself. That change worked great locally, but apparently it messed up menu painting over RDP.

This edition on the fix sets a flag on a WindowBase indicating that a menu redraw is necessary. We check that flag and perform the redraw as the menu is in the process of being displayed, thus ensuring only a single DrawMenuBar call that will capture all the previous mutations.

I also fixed a location where we should have been triggering a repaint but weren't.

I also fixed a regression: (*Menu).onInitPopup should be called with WindowBase.window as its argument, not the *WindowBase itself. The latter might cause issues for types implementing Window that have their own implementation of Window methods.

Updates https://github.com/tailscale/tailscale/issues/7698 Fixes #30