### PR TITLE
Improve robustness of (*NotifyIcon).reAddToTaskbar

### DIFF
--- a/form.go
+++ b/form.go
@@ -886,8 +886,6 @@ func (fb *FormBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 		}
 
 	case taskbarCreatedMsgId:
-		// Invalidate all NotifyIcon IDs by replacing the map, then re-add them.
-		notifyIconIDs = make(map[uint16]*NotifyIcon)
 		for ni := range notifyIcons {
 			ni.reAddToTaskbar()
 		}

--- a/menu.go
+++ b/menu.go
@@ -133,7 +133,6 @@ func (m *Menu) onInitPopup(window Window) {
 	m.initPopupPublisher.Publish()
 	m.perMenuMetrics.reset()
 	m.updateItemsForWindow(window)
-	window.AsWindowBase().redrawMenuBar()
 }
 
 func (m *Menu) Actions() *ActionList {
@@ -310,8 +309,6 @@ func (m *Menu) onActionChanged(action *Action) error {
 		}
 	}
 
-	m.ensureMenuBarRedrawn()
-
 	return nil
 }
 
@@ -386,13 +383,8 @@ func (m *Menu) removeAction(action *Action, visibleChanged bool) error {
 func (m *Menu) ensureMenuBarRedrawn() {
 	if m.window != nil {
 		if mw, ok := m.window.(*MainWindow); ok && mw.menu == m {
-			// If m is the top-level menu belonging to a MainWindow, redraw it immediately.
 			win.DrawMenuBar(mw.Handle())
-			return
 		}
-
-		// Otherwise we redraw the menu bar lazily when a popup menu is shown.
-		m.window.AsWindowBase().invalidateMenuBar()
 	}
 }
 

--- a/window.go
+++ b/window.go
@@ -448,7 +448,6 @@ type WindowBase struct {
 	suspended                 bool
 	visible                   bool
 	enabled                   bool
-	needDrawMenuBar           bool
 	acc                       *Accessibility
 	themes                    map[string]*Theme
 	menuSharedMetrics96DPI    *menuSharedMetrics
@@ -2382,19 +2381,6 @@ func (wb *WindowBase) menuSharedMetrics() *menuSharedMetrics {
 	return dpicache.InstanceForDPI(wb.menuSharedMetrics96DPI, wb.DPI())
 }
 
-func (wb *WindowBase) invalidateMenuBar() {
-	wb.needDrawMenuBar = true
-}
-
-func (wb *WindowBase) redrawMenuBar() {
-	if !wb.needDrawMenuBar {
-		return
-	}
-
-	wb.needDrawMenuBar = false
-	win.DrawMenuBar(wb.hWnd)
-}
-
 // WndProc is the window procedure of the window.
 //
 // When implementing your own WndProc to add or modify behavior, call the
@@ -2567,7 +2553,7 @@ func (wb *WindowBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 
 	case win.WM_INITMENUPOPUP:
 		if m := resolveMenu(win.HMENU(wParam)); m != nil {
-			m.onInitPopup(wb.window)
+			m.onInitPopup(wb)
 			return 0
 		}
 

--- a/window.go
+++ b/window.go
@@ -2553,7 +2553,7 @@ func (wb *WindowBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 
 	case win.WM_INITMENUPOPUP:
 		if m := resolveMenu(win.HMENU(wParam)); m != nil {
-			m.onInitPopup(wb)
+			m.onInitPopup(wb.window)
 			return 0
 		}
 


### PR DESCRIPTION
Walk watches for a notification from Windows when the taskbar is created. The
idea is if Explorer crashes or the walk app starts ahead of Explorer, then
walk will know when it should try re-adding notification icons to the taskbar.

Unfortunately the taskbar also exhibits this behaviour during a change in
the primary display's pixel density. This can happen when an RDP connection is
made, or when the device's monitor configuration changes. In this case,
the Explorer process never terminated, so when we try to re-add our icons,
the Shell_NotifyIcon call fails because the icons are technically still there!

We deal with this nonsense by simply failing out if the Shell_NotifyIcon call
fails; the icon presumably hasn't changed. OTOH, if the call succeeds, we
check the ID against the previous ID, and if there is a change, we update our
understanding of ID mappings accordingly.

Local testing confirmed this fix.