### PR TITLE
form.go, notifyicon.go, window.go: refactor NotifyIcon to use its own…

### DIFF
--- a/window.go
+++ b/window.go
@@ -2203,10 +2203,6 @@ func defaultWndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) (result u
 		}
 	}()
 
-	if msg == notifyIconMessageId {
-		return notifyIconWndProc(hwnd, msg, wParam, lParam)
-	}
-
 	wi := windowFromHandle(hwnd)
 	if wi == nil {
 		return win.DefWindowProc(hwnd, msg, wParam, lParam)


### PR DESCRIPTION
… hidden window

The previous implementation would associate notification icons with a Window specified at creation time, but this is quite different from how notification icons are usually done and was resulting in increased complexity.

Notification icons are typically associated with a dedicated hidden window for handling their messages. To achieve this, we remove the public API's ability to specify a Form argument. Instead, the notification icons manage their own windows. This allows us to do some nice things like reacting to messages in ways that wouldn't be otherwise possible.

In particular, when a notification icon window receives a WM_DISPLAYCHANGE, the window calls SetWindowPos to reset its position to (0,0). By doing so, we ensure that the window is always positioned on the primary monitor, which is the same monitor that the shell uses for displaying notification icons. By maintaining this invariant, we ensure that the DPI for the hidden notification icon window will always match the DPI of the shell's notification area (note that this would not be possible under the previous regime because the associated Form could be a visible window whose position is chosen by the user).

This allows us to remove a bunch of existing hacks that do all sorts of gymnastics to determine the shell's effective DPI.

Since I was already mucking around in this code, I also made it possible to use GUIDs to uniquely identify a notification icon. By using GUIDs we can prevent duplicate icons from appearing in the notification area if, for example, a previous app instance had crashed and a new instance has been started.

One catch with the GUID approach is that notification icons that use GUIDs cannot share their hidden windows; each instance must receive its own window. Notification icons that use the old (HWND, DWORD) tuple scheme may continue to share the same window.

Fixes #21
Updates https://github.com/tailscale/corp/issues/10851