### PR TITLE
mainloop_default.go, mainloop_cgo.go, windowgroup.go, window.go: use …

### DIFF
--- a/mainloop_cgo.go
+++ b/mainloop_cgo.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows && walk_use_cgo
 // +build windows,walk_use_cgo
 
 package walk
@@ -14,7 +15,6 @@ import (
 
 // #include <windows.h>
 //
-// extern void shimRunSynchronized(uintptr_t fb);
 // extern unsigned char shimHandleKeyDown(uintptr_t fb, uintptr_t m);
 //
 // static int mainloop(uintptr_t handle_ptr, uintptr_t fb_ptr)
@@ -35,7 +35,6 @@ import (
 //             TranslateMessage(&m);
 //             DispatchMessage(&m);
 //         }
-//         shimRunSynchronized(fb_ptr);
 //     }
 //     return 0;
 // }
@@ -44,11 +43,6 @@ import "C"
 //export shimHandleKeyDown
 func shimHandleKeyDown(fb uintptr, msg uintptr) bool {
 	return (*FormBase)(unsafe.Pointer(fb)).handleKeyDown((*win.MSG)(unsafe.Pointer(msg)))
-}
-
-//export shimRunSynchronized
-func shimRunSynchronized(fb uintptr) {
-	(*FormBase)(unsafe.Pointer(fb)).group.RunSynchronized()
 }
 
 func (fb *FormBase) mainLoop() int {

--- a/mainloop_default.go
+++ b/mainloop_default.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows && !walk_use_cgo
 // +build windows,!walk_use_cgo
 
 package walk
@@ -36,8 +37,6 @@ func (fb *FormBase) mainLoop() int {
 			win.TranslateMessage(msg)
 			win.DispatchMessage(msg)
 		}
-
-		fb.group.RunSynchronized()
 	}
 
 	return 0

--- a/window.go
+++ b/window.go
@@ -2116,8 +2116,6 @@ func (wb *WindowBase) BoundsChanged() *Event {
 // goroutine from inside a message loop.
 func (wb *WindowBase) Synchronize(f func()) {
 	wb.group.Synchronize(f)
-
-	win.PostMessage(wb.hWnd, syncMsgId, 0, 0)
 }
 
 // ThemeForClass obtains the theme associated with this Window whose class is
@@ -2145,8 +2143,6 @@ func (wb *WindowBase) ThemeForClass(themeClass string) (*Theme, error) {
 // will be replaced.
 func (wb *WindowBase) synchronizeLayout(result *formLayoutResult) {
 	wb.group.synchronizeLayout(result)
-
-	win.PostMessage(wb.hWnd, syncMsgId, 0, 0)
 }
 
 func (wb *WindowBase) ReadState() (string, error) {


### PR DESCRIPTION
…per-WindowGroup, hidden, message-only window to process synchronization messages

Directly calling (*WindowGroup).RunSynchronized from the message pump will not always work as expected: consider a nested message loop caused by something like a displaying menu or a dialog box. Sync messages are sent to the walk window and are dispatched to it, however that triggers an iteration of the *nested* message loop, not the outer *walk* message loop!

The way to fix this is to create a hidden, message-only window that can actually handle the sync message and dispatch its funcs.

Fixes https://github.com/tailscale/walk/issues/45