### PR TITLE
menu.go: add nil check to an action's OwnerDrawInfo before checking m…

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -427,9 +427,11 @@ func (m *Menu) onClearingActions() error {
 // by positional index.
 func (m *Menu) onMnemonic(key Key) (index, action uint16) {
 	m.actions.forEachVisible(func(a *Action) bool {
-		if aKey := a.ownerDrawInfo.mnemonic; aKey != 0 && aKey == key {
-			action = win.MNC_EXECUTE
-			return false
+		if odi := a.ownerDrawInfo; odi != nil {
+			if aKey := odi.mnemonic; aKey != 0 && aKey == key {
+				action = win.MNC_EXECUTE
+				return false
+			}
 		}
 
 		index++


### PR DESCRIPTION
…nemonic

I think what we're seeing here is an asynchronous update to a menu's ActionList, while that same menu is currently being displayed. This would not have been possible under the old (faulty) event loop code, but when I fixed that bug it introduced that possibility into this code.

Updates https://github.com/tailscale/tailscale/issues/9726