### PR TITLE
window.go: Refer directly to appSingleton when resolving Application …

### DIFF
--- a/window.go
+++ b/window.go
@@ -499,7 +499,7 @@ func mustAllocWindowClassMessage(className string) (msg uint32) {
 //
 // AllocWindowClassMessage must be called from the main goroutine.
 func AllocWindowClassMessage(className string) (uint32, error) {
-	App().AssertUIThread()
+	appSingleton.AssertUIThread()
 	if wcInfo := registeredWindowClasses[className]; wcInfo != nil {
 		return wcInfo.allocMessage()
 	}


### PR DESCRIPTION
…during window class registration

walk.App() is sometimes poorly suited for internal references to the app because it includes a bunch of checks to ensure that it is not being called too early in the application's lifecycle. On the other hand, internally to the framework, we sometimes need to be able to reference the app without those additional checks. This is one of those cases.