### PR TITLE
application.go, window.go: unconditionally return singleton pointer f…

### DIFF
--- a/application.go
+++ b/application.go
@@ -142,9 +142,8 @@ func init() {
 }
 
 var (
-	appOnce         onceWithPreInit
-	appSingleton    Application
-	appSingletonPtr *Application
+	appOnce      onceWithPreInit
+	appSingleton Application
 )
 
 // InitApp must be the first walk function called by the application. It
@@ -165,19 +164,18 @@ func InitApp() (app *Application, err error) {
 		}
 	}
 
-	appSingletonPtr = &appSingleton
 	return &appSingleton, nil
 }
 
 // App returns the *Application singleton. It panics if InitApp has not been
-// called yet and returns nil if InitApp failed.
+// called yet.
 //
 // App may be called from any goroutine once InitApp has completed successfully.
 func App() *Application {
 	appOnce.Init(func() {
 		panic("walk.InitApp must be called first")
 	})
-	return appSingletonPtr
+	return &appSingleton
 }
 
 // OrganizationName returns the string previously set by SetOrganizationName.

--- a/window.go
+++ b/window.go
@@ -2671,7 +2671,7 @@ func (wb *WindowBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 			return win.CallWindowProc(prevWndProc, hwnd, msg, wParam, lParam)
 		}
 
-	case App().cloakChangeMsg:
+	case appSingleton.cloakChangeMsg:
 		// No-op at the moment until we make window visibility aware of cloaking.
 		return 0
 	}


### PR DESCRIPTION
…rom App

During the review of a previous PR, we discussed altering the semantics of App() such that it returns nil if called after InitApp() has failed. Unfortunately Walk's pre-existing interdependencies are making that very difficult to achieve in the sort term. I am reverting that change with the intention of revisiting this in issue 61.