### PR TITLE
action.go, menu.go, declarative/action.go, examples/actions: fix radio button menu items

### DIFF
--- a/action.go
+++ b/action.go
@@ -522,7 +522,7 @@ func (a *Action) Triggered() *Event {
 
 func (a *Action) raiseTriggered() {
 	if a.Checkable() {
-		a.SetChecked(!a.Checked())
+		a.SetChecked(a.Exclusive() || !a.Checked())
 	}
 
 	a.triggeredPublisher.Publish()

--- a/declarative/action.go
+++ b/declarative/action.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package declarative
@@ -27,6 +28,7 @@ type Action struct {
 	Shortcut    Shortcut
 	OnTriggered walk.EventHandler
 	Checkable   bool
+	Exclusive   bool
 }
 
 func (a Action) createAction(builder *Builder, menu *walk.Menu) (*walk.Action, error) {
@@ -54,6 +56,10 @@ func (a Action) createAction(builder *Builder, menu *walk.Menu) (*walk.Action, e
 	}
 
 	if err := action.SetCheckable(a.Checkable || action.CheckedCondition() != nil); err != nil {
+		return nil, err
+	}
+
+	if err := action.SetExclusive(a.Exclusive); err != nil {
 		return nil, err
 	}
 

--- a/examples/actions/actions.go
+++ b/examples/actions/actions.go
@@ -5,13 +5,16 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/tailscale/walk"
 
 	. "github.com/tailscale/walk/declarative"
 )
 
+var viewModes [4]*walk.Action
 var isSpecialMode = walk.NewMutableCondition()
 
 type MyMainWindow struct {
@@ -112,16 +115,34 @@ func main() {
 					Image: "../img/document-properties.png",
 					Items: []MenuItem{
 						Action{
+							AssignTo:    &viewModes[0],
 							Text:        "X",
 							OnTriggered: mw.changeViewAction_Triggered,
+							Checkable:   true,
+							Exclusive:   true,
 						},
 						Action{
+							AssignTo:    &viewModes[1],
+							Text:        "(Hidden)",
+							OnTriggered: mw.changeViewAction_Triggered,
+							Checkable:   true,
+							Exclusive:   true,
+							Visible:     false,
+							Checked:     true,
+						},
+						Action{
+							AssignTo:    &viewModes[2],
 							Text:        "Y",
 							OnTriggered: mw.changeViewAction_Triggered,
+							Checkable:   true,
+							Exclusive:   true,
 						},
 						Action{
+							AssignTo:    &viewModes[3],
 							Text:        "Z",
 							OnTriggered: mw.changeViewAction_Triggered,
+							Checkable:   true,
+							Exclusive:   true,
 						},
 					},
 				},
@@ -197,7 +218,14 @@ func (mw *MyMainWindow) newAction_Triggered() {
 }
 
 func (mw *MyMainWindow) changeViewAction_Triggered() {
-	walk.MsgBox(mw, "Change View", "By now you may have guessed it. Nothing changed.", walk.MsgBoxIconInformation)
+	var msg strings.Builder
+	msg.WriteString("Current view mode:\n")
+	for _, m := range viewModes {
+		if m.Checked() {
+			fmt.Fprintf(&msg, " - %s\n", m.Text())
+		}
+	}
+	walk.MsgBox(mw, "Change View", msg.String(), walk.MsgBoxIconInformation)
 }
 
 func (mw *MyMainWindow) showAboutBoxAction_Triggered() {

--- a/menu.go
+++ b/menu.go
@@ -318,6 +318,10 @@ func (m *Menu) onActionChanged(action *Action) error {
 		if !win.CheckMenuRadioItem(m.hMenu, uint32(first), uint32(last), uint32(index), win.MF_BYPOSITION) {
 			return newError("CheckMenuRadioItem failed")
 		}
+
+		if err := m.actions.uncheckActionsForExclusiveCheck(first, last, index); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This prevents radio button menu items from being unchecked when a user selects an already checked item. It also updates other item states in an exclusivity group when a radio button menu item is checked programmatically or by a user.

Finally, it allows to create radio button menu items using the declarative syntax and updates examples/actions to demonstrate the new behavior.

Fixes #65