### PR TITLE
form.go: move final initialization to run later in the form's lifecycle

### DIFF
--- a/form.go
+++ b/form.go
@@ -144,7 +144,10 @@ func (fb *FormBase) init(form Form) error {
 	}
 
 	fb.performLayout, fb.layoutResults, fb.inSizeLoop, fb.updateStopwatch, fb.quitLayoutPerformer = startLayoutPerformer(fb)
+	return nil
+}
 
+func (fb *FormBase) start() {
 	if fb.owner != nil {
 		invalidateDescendentBorders := func() {
 			walkDescendants(fb.owner, func(wnd Window) bool {
@@ -173,8 +176,6 @@ func (fb *FormBase) init(form Form) error {
 	}
 
 	fb.SetSuspended(false)
-
-	return nil
 }
 
 func (fb *FormBase) Dispose() {
@@ -558,6 +559,8 @@ func (fb *FormBase) Show() {
 	if p, ok := fb.window.(Persistable); ok && p.Persistent() && App().Settings() != nil {
 		p.RestoreState()
 	}
+
+	fb.start()
 
 	fb.window.SetVisible(true)
 }


### PR DESCRIPTION
In 325926d94be67a5b2169e12c178bcc8de2914849 we moved the code from (*FormBase).Run() to (*FormBase).init and removed the former method altogether. This change affected the initialization order of a Window, causing nil pointer dereference errors during MainWindow creation.

This moves the original (*FormBase).Run() code back into its own method and calls it when the form is about to be displayed, ensuring that the window is fully initialized.

Fixes #cleanup