### PR TITLE
fix up some post-refactoring issues

### DIFF
--- a/action.go
+++ b/action.go
@@ -137,7 +137,7 @@ func (a *Action) finalize() {
 
 func (a *Action) addRef() {
 	a.refCount++
-	if a.refCount == 1 {
+	if a.refCount == 1 && a.id > maxReservedID {
 		actionsById[a.id] = a
 		if sc := a.shortcut; sc.Key != 0 {
 			shortcut2Action[sc] = a
@@ -147,7 +147,7 @@ func (a *Action) addRef() {
 
 func (a *Action) release() {
 	a.refCount--
-	if a.refCount == 0 {
+	if a.refCount == 0 && a.id > maxReservedID {
 		delete(actionsById, a.id)
 		if sc := a.shortcut; sc.Key != 0 && shortcut2Action[sc] == a {
 			delete(shortcut2Action, sc)
@@ -400,11 +400,10 @@ func (a *Action) SetShortcut(shortcut Shortcut) (err error) {
 		}
 
 		if a.refCount > 0 {
-			if shortcut.Key == 0 {
-				if shortcut2Action[old] == a {
-					delete(shortcut2Action, old)
-				}
-			} else {
+			if shortcut2Action[old] == a {
+				delete(shortcut2Action, old)
+			}
+			if shortcut.Key != 0 {
 				shortcut2Action[shortcut] = a
 			}
 		}

--- a/application.go
+++ b/application.go
@@ -654,7 +654,15 @@ func DefaultModalPreTranslate(m Modal, msg *win.MSG) bool {
 		return true
 	}
 
-	return win.IsDialogMessage(hwnd, msg)
+	if !win.IsDialogMessage(hwnd, msg) {
+		return false
+	}
+
+	// IsDialogMessage dispatched the message. Trigger OnPostDispatch if present.
+	if postDisp, hasPostDisp := m.(PostDispatchHandler); hasPostDisp {
+		postDisp.OnPostDispatch()
+	}
+	return true
 }
 
 func (app *Application) appendToWalkInit(fn func()) {


### PR DESCRIPTION
I fixed a couple of things that were bothering me in action.go and window.go, but the main thing that is actually a more significant bug is that FormBase's OnPostDispatch was not being invoked as frequently as it was pre-refactor.

There are two reasons for this. The first is that we should call the handler when IsDialogMessage returns true, as that should be treated as as dispatch. Secondly, we also need to handle messages that were dispatched to child windows of the form. In the case of issue 70, the toolbar was receiving a WM_COMMAND whose handler affected layout of the entire form. In that case, we implement OnPostDispatch on WidgetBase and forward it to the Form at the top of the hierarchy.

Fixes #70