### PR TITLE
Make WindowBase aware of high-contrast mode and use COLOR_WINDOW as i…

### DIFF
--- a/brush.go
+++ b/brush.go
@@ -155,6 +155,7 @@ var (
 	nullBrushSingleton   Brush
 	whiteBrushSingleton  Brush
 	sysColorBtnFaceBrush *SystemColorBrush
+	windowBrushSingleton Brush
 )
 
 func BlackBrush() Brush {
@@ -180,6 +181,7 @@ func init() {
 		nullBrushSingleton = newStockBrush(win.NULL_BRUSH)
 		whiteBrushSingleton = newStockBrush(win.WHITE_BRUSH)
 		sysColorBtnFaceBrush, _ = NewSystemColorBrush(SysColorBtnFace)
+		windowBrushSingleton, _ = NewSystemColorBrush(SysColorWindow)
 	})
 }
 

--- a/listbox.go
+++ b/listbox.go
@@ -2,6 +2,7 @@
 // Use of lb source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package walk
@@ -161,11 +162,7 @@ func (lb *ListBox) SetItemStyler(styler ListItemStyler) {
 func (lb *ListBox) ApplySysColors() {
 	lb.WidgetBase.ApplySysColors()
 
-	var hc win.HIGHCONTRAST
-	hc.CbSize = uint32(unsafe.Sizeof(hc))
-	if win.SystemParametersInfo(win.SPI_GETHIGHCONTRAST, hc.CbSize, unsafe.Pointer(&hc), 0) {
-		lb.style.highContrastActive = hc.DwFlags&win.HCF_HIGHCONTRASTON != 0
-	}
+	lb.style.highContrastActive = IsHighContrastEnabled()
 
 	lb.themeNormalBGColor = Color(win.GetSysColor(win.COLOR_WINDOW))
 	lb.themeNormalTextColor = Color(win.GetSysColor(win.COLOR_WINDOWTEXT))
@@ -204,7 +201,7 @@ func (lb *ListBox) itemString(index int) string {
 	}
 }
 
-//insert one item from list model
+// insert one item from list model
 func (lb *ListBox) insertItemAt(index int) error {
 	str := lb.itemString(index)
 	lp := uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(str)))

--- a/util.go
+++ b/util.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"github.com/tailscale/win"
 	"golang.org/x/exp/constraints"
@@ -650,4 +651,14 @@ func stripMargins(r *win.RECT, m win.MARGINS) {
 	r.Top += m.TopHeight
 	r.Right -= m.RightWidth
 	r.Bottom -= m.BottomHeight
+}
+
+// IsHighContrastEnabled returns whether the high-contrast accessibility setting
+// is currently enabled on this device.
+func IsHighContrastEnabled() bool {
+	hcSize := uint32(unsafe.Sizeof(win.HIGHCONTRAST{}))
+	hc := win.HIGHCONTRAST{
+		CbSize: hcSize,
+	}
+	return win.SystemParametersInfo(win.SPI_GETHIGHCONTRAST, hcSize, unsafe.Pointer(&hc), 0) && hc.DwFlags&win.HCF_HIGHCONTRASTON != 0
 }

--- a/window.go
+++ b/window.go
@@ -2360,7 +2360,18 @@ func (wb *WindowBase) handleKeyUp(wParam, lParam uintptr) {
 	wb.keyUpPublisher.Publish(Key(wParam))
 }
 
+// backgroundEffective returns the effective background brush for wb and the
+// Window that brush belongs to. The Window is returned for the purpose of
+// computing the brush origin.
 func (wb *WindowBase) backgroundEffective() (Brush, Window) {
+	if IsHighContrastEnabled() {
+		// If we're high contrast then our background needs to be windowBrushSingleton,
+		// which will be solid black. Since it's a solid colour, we do not need to
+		// concern ourselves with brush origin; we may therefore skip the parent
+		// traversal and simply return our own Window.
+		return windowBrushSingleton, wb.window
+	}
+
 	wnd := wb.window
 	bg := wnd.Background()
 


### PR DESCRIPTION
…ts background when enabled

We create a singleton for the COLOR_WINDOW system brush.

We update (*WindowBase).backgroundEffective() to always return said brush when high-contrast is enabled. We also add some additional documentation to that method to help explain its purpose.

Note that WM_SETTINGCHANGE always invalidates windows (via ApplySysColorser), so we should expect this to update on the fly on the rare occasion when walk windows are visible and high contrast mode is toggled.

Updates https://github.com/tailscale/corp/issues/23789