### PR TITLE
more fixes around DialogEx focus handling and default pushbuttons

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -339,7 +339,10 @@ func applyLayoutResults(results []LayoutResult, stopwatch *stopwatch) error {
 							activeForm, _ := windowFromHandle(hwndForm).(Form)
 
 							if hwndFocused == 0 || form.Handle() == hwndFocused || activeForm != window.Form() {
-								form.AsFormBase().clientComposite.focusFirstCandidateDescendant()
+								// Only set explicit focus if we're not a DialogEx.
+								if _, isDialogEx := form.(DialogExResolver); !isDialogEx {
+									form.AsFormBase().clientComposite.focusFirstCandidateDescendant()
+								}
 							}
 						}()
 					}

--- a/window.go
+++ b/window.go
@@ -456,6 +456,7 @@ type WindowBase struct {
 	suspended                   bool
 	visible                     bool
 	enabled                     bool
+	handlingFocusChange         bool
 	acc                         *Accessibility
 	themes                      map[string]*Theme
 	menuSharedMetricsInitialDPI *menuSharedMetrics
@@ -2553,6 +2554,11 @@ func (wb *WindowBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr)
 		wb.publishMouseWheelEvent(&wb.mouseWheelPublisher, wParam, lParam)
 
 	case win.WM_SETFOCUS, win.WM_KILLFOCUS:
+		wb.handlingFocusChange = true
+		defer func() {
+			wb.handlingFocusChange = false
+		}()
+
 		switch wnd := wb.window.(type) {
 		// case *splitterHandle:
 		// nop


### PR DESCRIPTION
I found some more areas inside existing walk code where it is trying to re-implement various dialog manager features that we want to avoid when using DialogEx:

* Form's WM_ACTIVATE handler tries to save and restore the currently focused widget. This competes with the dialog manager, so I added an override in DialogEx to only track the active form.
* I made WM_NEXTDLGCTL use SendMessage whenever possible by flagging when we're handling focus messages and only switching to PostMessage when we risk re-entering. We set that flag in WM_SETFOCUS and WM_KILLFOCUS handlers.
* I prevent layout from forcibly focusing widgets when the enclosing form is a DialogEx; we want that dealt with elsewhere.
* I created overrides for setCtrlID and clearCtrlID in PushButton that also set/clear BS_DEFPUSHBUTTON and re-focus the default pushbutton. This is necessary because setting focus to the default pushbutton typically happens when a dialog template is processed at creation time; of course, we're attaching widgets long after that has occurred. We also want to clear BS_DEFPUSHBUTTON once detaching widgets from the form, otherwise invalid state remains cached internally to Win32.

Updates https://github.com/tailscale/corp/issues/23789