### PR TITLE
fix layout and visibility issues breaking Taildrop send dialog

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -35,7 +35,7 @@ func createLayoutItemForWidgetWithContext(widget Widget, ctx *LayoutContext) Lay
 	lib := item.AsLayoutItemBase()
 	lib.ctx = ctx
 	lib.handle = widget.Handle()
-	lib.visible = widget.AsWidgetBase().visible
+	lib.visible = widget.AsWidgetBase().Visible()
 	lib.geometry = widget.AsWidgetBase().geometry
 	lib.geometry.Alignment = widget.Alignment()
 	lib.geometry.MinSize = widget.MinSizePixels()
@@ -71,7 +71,7 @@ func CreateLayoutItemsForContainerWithContext(container Container, ctx *LayoutCo
 	clib.ctx = ctx
 	clib.handle = container.Handle()
 	cb := container.AsContainerBase()
-	clib.visible = cb.visible
+	clib.visible = cb.Visible()
 	clib.geometry = cb.geometry
 	clib.geometry.ConsumingSpaceWhenInvisible = cb.AlwaysConsumeSpace()
 

--- a/splitter.go
+++ b/splitter.go
@@ -360,12 +360,12 @@ func (s *Splitter) onInsertedWidget(index int, widget Widget) (err error) {
 		layout.hwnd2Item[widget.Handle()] = item
 
 		layout.resetNeeded = true
-		if !layout.suspended && widget.AsWidgetBase().visible {
+		if !layout.suspended && widget.AsWidgetBase().Visible() {
 			s.RequestLayout()
 		}
 
 		item.visibleChangedHandle = widget.VisibleChanged().Attach(func() {
-			if !layout.suspended && widget.AsWidgetBase().visible != item.wasVisible {
+			if !layout.suspended && widget.AsWidgetBase().Visible() != item.wasVisible {
 				layout.resetNeeded = true
 				s.RequestLayout()
 			}
@@ -387,7 +387,7 @@ func (s *Splitter) onInsertedWidget(index int, widget Widget) (err error) {
 					index := offset + direction
 
 					for index >= 0 && index < len(s.children.items) {
-						if wb := s.children.items[index]; wb.visible {
+						if wb := s.children.items[index]; wb.Visible() {
 							return wb.window.(Widget)
 						}
 

--- a/splitterlayout.go
+++ b/splitterlayout.go
@@ -144,7 +144,7 @@ func (l *splitterLayout) SetStretchFactor(widget Widget, factor int) error {
 
 func (l *splitterLayout) anyNonFixed() bool {
 	for i, widget := range l.container.Children().items {
-		if i%2 == 0 && widget.visible && !l.Fixed(widget.window.(Widget)) {
+		if i%2 == 0 && widget.Visible() && !l.Fixed(widget.window.(Widget)) {
 			return true
 		}
 	}
@@ -159,7 +159,7 @@ func (l *splitterLayout) spaceUnavailableToRegularWidgets() int {
 	var space int
 
 	for _, widget := range l.container.Children().items {
-		if _, isHandle := widget.window.(*splitterHandle); isHandle && widget.visible {
+		if _, isHandle := widget.window.(*splitterHandle); isHandle && widget.Visible() {
 			space += splitter.handleWidth
 		}
 	}

--- a/toolbar.go
+++ b/toolbar.go
@@ -58,7 +58,7 @@ func NewToolBarWithOrientationAndButtonStyle(parent Container, orientation Orien
 		tb,
 		parent,
 		"ToolbarWindow32",
-		win.CCS_NODIVIDER|win.TBSTYLE_FLAT|win.TBSTYLE_TOOLTIPS|style,
+		win.WS_TABSTOP|win.WS_VISIBLE|win.CCS_NODIVIDER|win.TBSTYLE_FLAT|win.TBSTYLE_TOOLTIPS|style,
 		0); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* We get rid of the visible flag in WindowBase; this flag tends to become out of sync with the real state in the window manager. We replace references to it with calls to Visible(), which queries the system instead. Yet another reinforcement of the principle that UI frameworks should not attempt to keep their own copy of window state.
* We set WS_EX_CONTROLPARENT on group box controls.
* We remove control IDs that were being set on the components of GroupBox. Generally group boxes don't need those. I _could_ see an argument for applying an ID to the checkbox that walk supports, however it would need to use the control ID allocator stuff. Since we're not using that, I'm just removing the IDs.
* We fix the CreateWindowEx call for toolbars to include WS_TABSTOP and WS_VISIBLE to bring them into line with other widgets; generally walk expects newly-created windows to be visible.

Updates https://github.com/tailscale/corp/issues/24894