### PR TITLE
widget.go: ensure we have a non-nil form before requesting control ID…

### DIFF
--- a/widget.go
+++ b/widget.go
@@ -389,13 +389,15 @@ func (wb *WidgetBase) SetParent(parent Container) (err error) {
 }
 
 func (wb *WidgetBase) assignCtrlIDs() {
-	form := wb.ancestor()
-	form.AsFormBase().assignCtrlIDs(wb)
+	if form := wb.ancestor(); form != nil {
+		form.AsFormBase().assignCtrlIDs(wb)
+	}
 }
 
 func (wb *WidgetBase) revokeCtrlIDs() {
-	form := wb.ancestor()
-	form.AsFormBase().revokeCtrlIDs(wb)
+	if form := wb.ancestor(); form != nil {
+		form.AsFormBase().revokeCtrlIDs(wb)
+	}
 }
 
 func (wb *WidgetBase) ForEachAncestor(f func(window Window) bool) {


### PR DESCRIPTION
… allocation or revocation

This prevents panics when attaching to containers that are not yet attached to a Form.

Fixes #107