### PR TITLE
application.go: Add Go method and WaitGroup to Application

### DIFF
--- a/gridlayout.go
+++ b/gridlayout.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package walk
@@ -445,6 +446,7 @@ func (li *gridLayoutItem) MinSizeForSize(size Size) Size {
 				if hfw, ok := item.(HeightForWidther); ok && hfw.HasHeightForWidth() {
 					wg.Add(1)
 
+					// Already in a WaitGroup, so not using App().Go() here.
 					go func() {
 						height := hfw.HeightForWidth(li.spannedWidth(info, widths))
 


### PR DESCRIPTION
Sometimes when quitting a walk application built in debug mode, I see panics from goroutines that have not finished running by the time the process terminates. While sometimes this doesn't matter, there are other times when we'd like to ensure that goroutines have finished.

I added a new Go method to Application that spawns goroutines that will be associated with a WaitGroup and the Application's Context. (*Application).Run is modified to wait on that WaitGroup before returning.

I also updated layout code to use (*Application).Go instead of directly spawning goroutines.

Fixes #110