### PR TITLE
layout.go: fix stupid typo made in 6508f86cca3d2d13d77123cd10cf872d9c…

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -232,7 +232,7 @@ func layoutTree(startInfo layoutStartInfo, size Size, cancel chan struct{}, done
 		}()
 
 		var wg sync.WaitGroup
-		layoutSubtree =: func(container ContainerLayoutItem, size Size) {
+		layoutSubtree := func(container ContainerLayoutItem, size Size) {
 			wg.Add(1)
 
 			// We don't use App().Go() here because it's already in a WaitGroup


### PR DESCRIPTION
…942006

This is #cleanup