### PR TITLE
layout.go: revert back to separate declaration and assignment of layo…

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -232,7 +232,11 @@ func layoutTree(startInfo layoutStartInfo, size Size, cancel chan struct{}, done
 		}()
 
 		var wg sync.WaitGroup
-		layoutSubtree := func(container ContainerLayoutItem, size Size) {
+
+		// Need to declare layoutSubtree before assigning it because of recursion
+		// in its implementation.
+		var layoutSubtree func(container ContainerLayoutItem, size Size)
+		layoutSubtree = func(container ContainerLayoutItem, size Size) {
 			wg.Add(1)
 
 			// We don't use App().Go() here because it's already in a WaitGroup


### PR DESCRIPTION
…utSubtree due to recursion

This is #cleanup