### PR TITLE
layout.go: Fix double-close of quit channel

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -172,7 +172,6 @@ func startLayoutPerformer(form Form) (performLayout chan layoutStartInfo, layout
 					close(cancel)
 				}
 				close(done)
-				close(quit)
 				return
 			}
 		}


### PR DESCRIPTION
Fixes #124