### PR TITLE
form.go, notifyicon.go: Improved tracking of modal loops

### DIFF
--- a/form.go
+++ b/form.go
@@ -66,6 +66,11 @@ type Form interface {
 
 	// SetFocusToWindow sets keyboard focus to the Window specified by w.
 	SetFocusToWindow(w Window)
+
+	// EnteringMode returns the event that is triggered if the Form is entering
+	// a modal loop. Use [Disposing] to for notification when the Form is leaving
+	// the modal loop.
+	EnteringMode() *Event
 }
 
 type FormBase struct {
@@ -84,6 +89,7 @@ type FormBase struct {
 	startingPublisher           EventPublisher
 	titleChangedPublisher       EventPublisher
 	iconChangedPublisher        EventPublisher
+	enteringModePublisher       EventPublisher
 	progressIndicator           *ProgressIndicator
 	icon                        Image
 	prevFocusHWnd               win.HWND
@@ -512,6 +518,10 @@ func (fb *FormBase) Starting() *Event {
 	return fb.startingPublisher.Event()
 }
 
+func (fb *FormBase) EnteringMode() *Event {
+	return fb.enteringModePublisher.Event()
+}
+
 func (fb *FormBase) Activating() *Event {
 	return fb.activatingPublisher.Event()
 }
@@ -908,6 +918,7 @@ func (fb *FormBase) WndProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) u
 }
 
 func (fb *FormBase) EnterMode() {
+	fb.enteringModePublisher.Publish()
 }
 
 func (fb *FormBase) Running() bool {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/dblohm7/wingoes v0.0.0-20231019175336-f6e33aa7cc34
-	github.com/tailscale/win v0.0.0-20241018163102-cfd3289ef17f
+	github.com/tailscale/win v0.0.0-20250213223159-5992cb43ca35
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/sys v0.8.0
 	gopkg.in/Knetic/govaluate.v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/dblohm7/wingoes v0.0.0-20231019175336-f6e33aa7cc34 h1:FBMro26TLQwBk+n4fbTSmSf3QUKb09pvW4fz49lxpl0=
 github.com/dblohm7/wingoes v0.0.0-20231019175336-f6e33aa7cc34/go.mod h1:6NCrWM5jRefaG7iN0iMShPalLsljHWBh9v1zxM2f8Xs=
-github.com/tailscale/win v0.0.0-20241018163102-cfd3289ef17f h1:13CyO8FO3blZH04ewuT9DDgm9V7G0CfjDzw8kLKx+s8=
-github.com/tailscale/win v0.0.0-20241018163102-cfd3289ef17f/go.mod h1:aMd4yDHLjbOuYP6fMxj1d9ACDQlSWwYztcpybGHCQc8=
+github.com/tailscale/win v0.0.0-20250213223159-5992cb43ca35 h1:wAZbkTZkqDzWsqxPh2qkBd3KvFU7tcxV0BP0Rnhkxog=
+github.com/tailscale/win v0.0.0-20250213223159-5992cb43ca35/go.mod h1:aMd4yDHLjbOuYP6fMxj1d9ACDQlSWwYztcpybGHCQc8=
 golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
 golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=


### PR DESCRIPTION
For Form, we add a new event that is published if EnterMode is called.

For NotifyIcons, we move tracking whether existing context menus are active to handlers for WM_ENTERMENULOOP and WM_EXITMENULOOP, as these messages give us more precise notification as to when menu(s) are present. We also change the tracking variable from a bool to an int, since Win32 APIs to permit nested context menus when specific flags are provided.

We also pick up the latest revision of win.

Updates https://github.com/tailscale/corp/issues/26617