### PR TITLE
taskdialog.go: ignore CommandLinkMode if a dialog has no custom buttons

### DIFF
--- a/taskdialog.go
+++ b/taskdialog.go
@@ -376,12 +376,14 @@ func (td *taskDialog) Show(opts TaskDialogOpts) (result TaskDialogResult, err er
 	default:
 	}
 
-	switch opts.CommandLinkMode {
-	case TaskDialogCommandLinks:
-		flags |= win.TDF_USE_COMMAND_LINKS_NO_ICON
-	case TaskDialogCommandLinksWithGlyph:
-		flags |= win.TDF_USE_COMMAND_LINKS
-	default:
+	if len(opts.CustomButtons) > 0 {
+		switch opts.CommandLinkMode {
+		case TaskDialogCommandLinks:
+			flags |= win.TDF_USE_COMMAND_LINKS_NO_ICON
+		case TaskDialogCommandLinksWithGlyph:
+			flags |= win.TDF_USE_COMMAND_LINKS
+		default:
+		}
 	}
 
 	defaultRadioButtonID := td.defaultRadioButtonID()


### PR DESCRIPTION
Fixes #131