### PR TITLE
menu.go: ensure that owner-draw/bitmap separators are flagged as such

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -239,10 +239,15 @@ func (m *Menu) initMenuItemInfoFromAction(mii *win.MENUITEMINFO, action *Action)
 		if bmp, err := iconCache.Bitmap(action.image, dpi); err == nil {
 			mii.HbmpItem = bmp.hBmp
 		}
-	case action.IsSeparator():
+	default:
+	}
+
+	// Being a separator is not mutually-exclusive to being an image or
+	// owner-draw item, so we must perform this check separately from the
+	// switch above.
+	if action.IsSeparator() {
 		mii.FType |= win.MFT_SEPARATOR
 		setString = false
-	default:
 	}
 
 	if setString {


### PR DESCRIPTION
The code that flags separators was being treated as mutually-exculsive to owner-draw/bitmap items. We move the separator stuff out of the switch block into its own if statement to ensure that it is always run regardless of an item's owner-draw/bitmap setting.

Updates https://github.com/tailscale/tailscale/issues/17535