### PR TITLE
Fix layoutFlags assignment in CreateLayoutItem method

### DIFF
--- a/separator.go
+++ b/separator.go
@@ -41,9 +41,9 @@ func newSeparator(parent Container, vertical bool) (*Separator, error) {
 func (s *Separator) CreateLayoutItem(ctx *LayoutContext) LayoutItem {
 	var layoutFlags LayoutFlags
 	if s.vertical {
-		layoutFlags = GrowableHorz | GreedyHorz
-	} else {
 		layoutFlags = GrowableVert | GreedyVert
+	} else {
+		layoutFlags = GrowableHorz | GreedyHorz
 	}
 
 	return &separatorLayoutItem{


### PR DESCRIPTION
These were switched, causing a horizontal separator to appear as a vertical one and presumably vice versa.

```go
mainWindow, err := walk.NewMainWindowWithCfg(&walk.MainWindowCfg{})

...

mainLayout = walk.NewVBoxLayout()
mainWindow.SetLayout(mainLayout)

...

separator, _ := walk.NewHSeparator(w.mainWindow)
```

Before:

<img width="582" height="471" alt="image" src="https://github.com/user-attachments/assets/0fff3e5b-0baf-4d2f-aeeb-942b81a1174d" />

After:

<img width="585" height="472" alt="image" src="https://github.com/user-attachments/assets/2e8d4db2-f1a1-432a-8c82-1b7560359ac9" />